### PR TITLE
Cleanup

### DIFF
--- a/manifests/trueos-snapshot.json
+++ b/manifests/trueos-snapshot.json
@@ -1,120 +1,111 @@
 {
-  "base-packages": {
-    "world-flags": {
-      "default": [
-      ]
-    },
-    "kernel-flags": {
-      "default": [
-      ]
-    }
-  },
-  "iso": {
-    "auto-install-packages": {
-      "default": [
-        "ports-mgmt/poudriere",
-	"os/userland",
-	"os/docs",
-	"os/kernel",
-	"security/sudo",
-        "sysutils/ipmitool",
-        "sysutils/dmidecode",
-        "sysutils/tmux",
-        "security/ca_root_nss",
-	"sysutils/sysup",
-	"textproc/jq",
-        "www/nginx"
-      ]
-    },
-    "auto-install-script": "",
-    "dist-packages": {
-      "default": []
-    },
-    "file-name": "TrueOS-Snapshot-x64-%%DATE%%",
-    "install-script": "",
-    "iso-packages": {
-      "default": [
-      ]
-    },
-    "overlay": "",
-    "prune": {
-      "default": [
-	"METALOG",
-	"/usr/local/share/examples",
-        "/usr/local/include",
-        "/usr/bin/cc*",
-        "/usr/bin/clang*",
-        "/usr/bin/cpp",
-        "/usr/bin/cpp",
-        "/usr/bin/c++",
-        "/usr/bin/lldb",
-        "/usr/bin/ld.lld",
-        "/usr/bin/llvm*",
-        "/usr/bin/objdump*",
-        "/usr/bin/svn*",
-	"/usr/lib/clang",
-	"/usr/share/man",
-	"/usr/share/i18n",
-	"/usr/share/openssl/man",
-	"/usr/include",
-	"/usr/lib32"
-      ]
-    }
-  },
-  "pkg-repo": {
-    "pubKey": [
-      "-----BEGIN PUBLIC KEY-----",
-      "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAx4YxSavJkE7HjopkMtgK",
-      "tk/plcnImzfx0MmdK3ijv2724+v810kbAmRI01aiooQvusfcQ5OOyNpAzxwKMTTB",
-      "6bo46YtrnYBTP5G1mNqTRxL5Sg03Kpwcb6fCZ4gYOqTNPmhV6BskhRrfGOzNazcd",
-      "cb8CeqTeL7A44vwkyufQrSNgT9+ByCGuxaEp2os+GEbELyWZMmpQD6s2gAgpXuB6",
-      "K/f7pm9ZsULjJ+ZKc31TjgMTyVA07niocjDxiD2KVEbiagirnxA7BLa66u58B1ol",
-      "tnvOD8JNkGONT2LJhWOMXowZ8fCQ6Ec6ws2SY0UJ14d4w7xnz7U9+STHRYlJnNyl",
-      "ZYNLZ7UK7zyILWhAjkmq3TUaw7o456+QIyf4hA/he9UZhwhgRGNjJCUATbEUT+PF",
-      "65ox6+rT5g/jjDlY6kxfvLCTYJG/Arlj9FCAV/vBa/0lUu1OjivxPNK694G4tVHl",
-      "/z1yApzgzbOgkOY1caPCkGgniD2N4rySm744RxVXonrKmso9nsG0tGrDTC72M39Y",
-      "xgzt2x+NCDhBxZ6EWkqXH6Xk5yOPUV8XDTjqwOnm4XvyD9jzxAiK9Bex6CxKNfph",
-      "9p42Kr3QZPVXjZofqcfhJxZ4Nv0s09K1R1yqNzMmO7Aa2uF2F6ChQ/m6Z41hdaeO",
-      "AxxsOeRYAlBFJ4oo2cFVyqkCAwEAAQ==",
-      "-----END PUBLIC KEY-----"
-    ],
-    "url": "https://pkg.trueos.org/pkg/snapshot/${ABI}/latest"
-  },
-  "pkg-repo-name": "TrueOS",
-  "pkg-train-name": "snapshot",
-  "ports": {
-    "branch": "trueos-master",
-    "build": {
-      "default": [
-        "archivers/pigz",
-        "devel/gdb",
-        "devel/git",
-        "devel/jenkins",
-        "dns/mDNSResponder_nss",
-        "editors/vim-console",
-        "lang/python",
-        "lang/python2",
-        "lang/python3",
-        "net/rsync",
-        "ports-mgmt/poudriere-trueos",
-	"sysutils/ec2-scripts",
-	"textproc/jq"
-      ]
-    },
-    "build-all": false,
-    "make.conf": {
-      "default": [
-        "MAKE_JOBS_NUMBER_LIMIT=3",
-        "MALLOC_PRODUCTION=YES"
-      ]
-    },
-    "src.conf": {
-      "default": [
-        "WITHOUT_ASSERT_DEBUG=ON"
-      ]
-    },
-    "type": "git",
-    "url": "https://github.com/trueos/trueos-ports"
-  },
-  "version": "1.1"
+	"base-packages": {
+		"world-flags": {
+			"default": [
+				"MALLOC_PRODUCTION=YES",
+				"WITHOUT_ASSERT_DEBUG=ON"
+			]
+		},
+		"kernel-flags": {
+			"default": []
+		}
+	},
+	"iso": {
+		"auto-install-packages": {
+			"default": [
+				"os/userland",
+				"os/docs",
+				"os/kernel",
+				"security/sudo",
+				"sysutils/ipmitool",
+				"sysutils/dmidecode",
+				"sysutils/tmux",
+				"security/ca_root_nss",
+				"sysutils/sysup",
+				"textproc/jq",
+				"www/nginx"
+			]
+		},
+		"auto-install-script": "",
+		"dist-packages": {
+			"default": []
+		},
+		"file-name": "TrueOS-Snapshot-x64-%%DATE%%",
+		"install-script": "",
+		"iso-packages": {
+			"default": []
+		},
+		"overlay": "",
+		"prune": {
+			"default": [
+				"METALOG",
+				"/usr/local/share/examples",
+				"/usr/local/include",
+				"/usr/bin/cc*",
+				"/usr/bin/clang*",
+				"/usr/bin/cpp",
+				"/usr/bin/cpp",
+				"/usr/bin/c++",
+				"/usr/bin/lldb",
+				"/usr/bin/ld.lld",
+				"/usr/bin/llvm*",
+				"/usr/bin/objdump*",
+				"/usr/bin/svn*",
+				"/usr/lib/clang",
+				"/usr/share/man",
+				"/usr/share/i18n",
+				"/usr/share/openssl/man",
+				"/usr/include",
+				"/usr/lib32"
+			]
+		}
+	},
+	"pkg-repo": {
+		"pubKey": [
+			"-----BEGIN PUBLIC KEY-----",
+			"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAx4YxSavJkE7HjopkMtgK",
+			"tk/plcnImzfx0MmdK3ijv2724+v810kbAmRI01aiooQvusfcQ5OOyNpAzxwKMTTB",
+			"6bo46YtrnYBTP5G1mNqTRxL5Sg03Kpwcb6fCZ4gYOqTNPmhV6BskhRrfGOzNazcd",
+			"cb8CeqTeL7A44vwkyufQrSNgT9+ByCGuxaEp2os+GEbELyWZMmpQD6s2gAgpXuB6",
+			"K/f7pm9ZsULjJ+ZKc31TjgMTyVA07niocjDxiD2KVEbiagirnxA7BLa66u58B1ol",
+			"tnvOD8JNkGONT2LJhWOMXowZ8fCQ6Ec6ws2SY0UJ14d4w7xnz7U9+STHRYlJnNyl",
+			"ZYNLZ7UK7zyILWhAjkmq3TUaw7o456+QIyf4hA/he9UZhwhgRGNjJCUATbEUT+PF",
+			"65ox6+rT5g/jjDlY6kxfvLCTYJG/Arlj9FCAV/vBa/0lUu1OjivxPNK694G4tVHl",
+			"/z1yApzgzbOgkOY1caPCkGgniD2N4rySm744RxVXonrKmso9nsG0tGrDTC72M39Y",
+			"xgzt2x+NCDhBxZ6EWkqXH6Xk5yOPUV8XDTjqwOnm4XvyD9jzxAiK9Bex6CxKNfph",
+			"9p42Kr3QZPVXjZofqcfhJxZ4Nv0s09K1R1yqNzMmO7Aa2uF2F6ChQ/m6Z41hdaeO",
+			"AxxsOeRYAlBFJ4oo2cFVyqkCAwEAAQ==",
+			"-----END PUBLIC KEY-----"
+		],
+		"url": "https://pkg.trueos.org/pkg/snapshot/${ABI}/latest"
+	},
+	"pkg-repo-name": "TrueOS",
+	"pkg-train-name": "snapshot",
+	"ports": {
+		"branch": "trueos-master",
+		"build": {
+			"default": [
+				"archivers/pigz",
+				"devel/gdb",
+				"devel/git",
+				"devel/jenkins",
+				"dns/mDNSResponder_nss",
+				"editors/vim-console",
+				"lang/python",
+				"lang/python2",
+				"lang/python3",
+				"net/rsync",
+				"ports-mgmt/poudriere-trueos",
+				"sysutils/ec2-scripts",
+				"textproc/jq"
+			]
+		},
+		"build-all": false,
+		"make.conf": {
+			"default": []
+		},
+		"type": "git",
+		"url": "https://github.com/trueos/trueos-ports"
+	},
+	"version": "1.1"
 }


### PR DESCRIPTION
- Remove MAKE_JOBS_NUMBER_LIMIT=3 we really dont need this limitation anymore poudriere and also src have been a lot improved over the years on balancing the cpus correctly
- remove ports-mgmt/poudriere since its a must to have poudriere-trueos otherwise u cant build base anymore
- Move MALLOC_PRODUCTION=YES to the world flag section in order to get correct detected.
- Move WITHOUT_ASSERT_DEBUG=ON to world flags as well because we dont read src.conf
- Remove src.conf target we dont support that anymore (or never did ^^)
- Json format and validated