### PR TITLE
Update FreeNAS Manifest

### DIFF
--- a/manifests/freenas-12-stable.json
+++ b/manifests/freenas-12-stable.json
@@ -1,416 +1,254 @@
 {
-  "base-packages": {
-    "kernel-flags": {
-      "default": [
-        "KERNCONF=IXNAS"
-      ]
-    }
-  },
-  "poudriere": {
-      "jailname": "freenas",
-      "portsname": "freenas"
-  },
-  "iso": {
-    "auto-install-packages": {
-      "default": [
-        "archivers/liblz4",
-        "archivers/lzo2",
-        "archivers/pigz",
-        "archivers/plzip",
-        "benchmarks/fio",
-        "benchmarks/iozone",
-        "benchmarks/iperf",
-        "benchmarks/iperf3",
-        "benchmarks/netperf",
-        "comms/lrzsz",
-        "converters/base64",
-        "converters/convmv",
-        "databases/py-bsddb3",
-        "databases/py-sqlite3",
-        "databases/rrdtool",
-        "databases/sqlite3",
-        "devel/dbus",
-        "devel/dbus-glib",
-        "devel/gdb",
-        "devel/git-lite",
-        "devel/glib20",
-        "devel/libhyve-remote",
-        "devel/py-daemon",
-        "devel/py-dateutil",
-        "devel/py-ipaddr",
-        "devel/py-pyparsing",
-        "devel/py-setproctitle",
-        "devel/py-sysctl",
-        "devel/py-xattr",
-        "dns/bind-tools",
-        "dns/dnsmasq",
-        "dns/inadyn-mt",
-        "dns/inadyn-troglobit",
-        "dns/mDNSResponder_nss",
-        "dns/py-bonjour",
-        "dns/py-dnspython",
-        "dns/samba-nsupdate",
-        "editors/jed",
-        "editors/nano",
-        "emulators/mtools",
-        "emulators/open-vm-tools-nox11",
-        "emulators/virtualbox-ose-kmod",
-        "ftp/curl",
-        "ftp/proftpd",
-        "ftp/wget",
-        "freenas/freenas-files",
-        "freenas/freenas-migrate93",
-        "freenas/freenas-pkgtools",
-        "freenas/freenas-ui",
-        "freenas/freenas-webui",
-        "freenas/pipewatcher",
-        "freenas/py-bsd",
-        "freenas/py-licenselib",
-        "freenas/py-middlewared",
-        "freenas/swagger-ui",
-	"graphics/drm-fbsd12.0-kmod",
-        "graphics/cairo",
-        "graphics/graphite2",
-        "lang/python",
-        "lang/python2",
-        "lang/python27",
-        "lang/python3",
-        "misc/cpuid",
-        "misc/mbuffer",
-        "misc/mc",
-        "misc/mmv",
-        "misc/xtail",
-        "net/ladvd",
-        "net/libdnet",
-        "net/libvncserver",
-        "net/mDNSResponder",
-        "net/mosh",
-        "net/netatalk3",
-        "net/nsq",
-        "net/nss-pam-ldapd-sasl",
-        "net/openldap24-sasl-client",
-        "net/py-oauth2",
-        "net/py-ldap",
-        "net/py-pynsq",
-        "net/py-pyvmomi",
-        "net/py-s3cmd",
-        "net/rsync",
-        "net/samba49",
-        "net/smbldap-tools",
-        "net/trafshow",
-        "net/viamillipede",
-        "net/zerotier",
-        "net/unison",
-        "net-mgmt/clog",
-        "net-mgmt/collectd5",
-        "net-mgmt/net-snmp",
-        "net-mgmt/netdata",
-        "net-mgmt/sipcalc",
-	"os/kernel",
-	"os/userland",
-        "print/harfbuzz",
-        "security/ca_root_nss",
-        "security/cyrus-sasl2-gssapi",
-        "security/easy-rsa",
-        "security/gnupg",
-        "security/openssh-portable",
-        "security/openvpn",
-        "security/pam_mkhomedir",
-        "security/py-openssl",
-        "security/py-paramiko",
-        "security/py-pycryptodome",
-        "security/sssd",
-        "security/sudo",
-        "security/stunnel",
-        "shells/bash",
-        "shells/ksh93",
-        "shells/mksh",
-        "shells/scponly",
-        "shells/zsh",
-        "sysutils/ataidle",
-        "sysutils/beadm",
-        "sysutils/cmdwatch",
-        "sysutils/devcpu-data",
-        "sysutils/dmidecode",
-        "sysutils/e2fsprogs",
-        "sysutils/fusefs-libs",
-        "sysutils/fusefs-ntfs",
-        "sysutils/fusefs-s3fs",
-        "sysutils/gnome_subr",
-        "sysutils/graid5",
-        "sysutils/grub2-bhyve",
-        "sysutils/htop",
-        "sysutils/iocage",
-        "sysutils/iohyve",
-        "sysutils/ipfs-go",
-        "sysutils/ipmitool",
-        "sysutils/jailme",
-        "sysutils/lsof",
-        "sysutils/megacli",
-        "sysutils/ncdu",
-        "sysutils/nut",
-        "sysutils/pciutils",
-        "sysutils/pv",
-        "sysutils/screen",
-        "sysutils/sedutil",
-        "sysutils/sg3_utils",
-        "sysutils/smartmontools",
-        "sysutils/smp_utils",
-        "sysutils/syslog-ng",
-        "sysutils/throttle",
-        "sysutils/tmux",
-        "sysutils/tw_cli",
-        "sysutils/uefi-edk2-bhyve",
-        "sysutils/uefi-edk2-bhyve-csm",
-        "sysutils/vm-bhyve",
-        "sysutils/zfs-stats-lite",
-        "textproc/jq",
-        "www/apache24",
-        "www/dojo",
-        "www/minio",
-        "www/mod_mpm_itk",
-        "www/nginx",
-        "www/novnc",
-        "www/novnc-websockify",
-        "www/py-dojango",
-        "www/py-httplib2",
-        "www/wgetpaste"
-      ]
-    },
-    "auto-install-script": "",
-    "dist-packages": {},
-    "prune": {
-      "default": [
-	"METALOG",
-	"/usr/local/share/examples",
-        "/usr/local/include",
-        "/usr/bin/cc*",
-        "/usr/bin/clang*",
-        "/usr/bin/cpp",
-        "/usr/bin/cpp",
-        "/usr/bin/c++",
-        "/usr/bin/lldb",
-        "/usr/bin/ld.lld",
-        "/usr/bin/llvm*",
-        "/usr/bin/objdump*",
-        "/usr/bin/svn*",
-	"/usr/lib/clang",
-	"/usr/share/man",
-	"/usr/share/i18n",
-	"/usr/share/openssl/man",
-	"/usr/include",
-	"/usr/lib32"
-      ]
-    },
-    "file-name": "FreeNAS-12-unstable-x64-%%DATE%%",
-    "install-script": "",
-    "iso-packages": {
-      "default": [ ]
-    },
-    "offline-update":true,
-    "overlay": {},
-        "pool": {
-            "name":"freenas-boot"
-    },
-    "os_name": "FreeNAS",
-    "post-install-commands": [
-      {
-        "chroot":true,
-        "command":"sysrc -f /boot/loader.conf rc_system=rc"
-      },
-      {
-        "chroot":true,
-        "command":"touch /etc/dynamicdiskless"
-      },
-      {
-        "chroot":true,
-        "command":"mkdir -p /conf/base/etc"
-      },
-      {
-        "chroot":true,
-        "command":"echo 65535 > /conf/base/etc/md_size"
-      },
-      {
-        "chroot":true,
-        "command":"mkdir -p /conf/base/var"
-      },
-      {
-        "chroot":true,
-        "command":"mkdir -p /conf/base/mnt"
-      },
-      {
-        "chroot":true,
-        "command":"echo 8192 > /conf/base/mnt/md_size"
-      },
-      {
-        "chroot":true,
-        "command":"mkdir -p /conf/base/usr__local__etc"
-      },
-      {
-        "chroot":true,
-        "command":"echo 65535 > /conf/base/usr__local__etc/md_size"
-      },
-      {
-        "chroot":true,
-        "command":"ln -s /usr/local/etc /etc/local"
-      },
-      {
-        "chroot":true,
-        "command":"ln -fs /var/tmp/.rnd /.rnd"
-      },
-      {
-        "chroot":false,
-        "command":"zfs destroy freenas-boot/tmp"
-      },
-      {
-        "chroot":true,
-        "command":"rm -rf /tmp"
-      },
-      {
-        "chroot":true,
-        "command":"ln -fs /var/tmp /tmp"
-      }
-
-    ]
-  },
-  "os_name":"FreeNAS",
-  "os_version":"12-STABLE",
-  "pkg-repo": {
-    "pubKey": [
-      "-----BEGIN PUBLIC KEY-----",
-      "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAx4YxSavJkE7HjopkMtgK",
-      "tk/plcnImzfx0MmdK3ijv2724+v810kbAmRI01aiooQvusfcQ5OOyNpAzxwKMTTB",
-      "6bo46YtrnYBTP5G1mNqTRxL5Sg03Kpwcb6fCZ4gYOqTNPmhV6BskhRrfGOzNazcd",
-      "cb8CeqTeL7A44vwkyufQrSNgT9+ByCGuxaEp2os+GEbELyWZMmpQD6s2gAgpXuB6",
-      "K/f7pm9ZsULjJ+ZKc31TjgMTyVA07niocjDxiD2KVEbiagirnxA7BLa66u58B1ol",
-      "tnvOD8JNkGONT2LJhWOMXowZ8fCQ6Ec6ws2SY0UJ14d4w7xnz7U9+STHRYlJnNyl",
-      "ZYNLZ7UK7zyILWhAjkmq3TUaw7o456+QIyf4hA/he9UZhwhgRGNjJCUATbEUT+PF",
-      "65ox6+rT5g/jjDlY6kxfvLCTYJG/Arlj9FCAV/vBa/0lUu1OjivxPNK694G4tVHl",
-      "/z1yApzgzbOgkOY1caPCkGgniD2N4rySm744RxVXonrKmso9nsG0tGrDTC72M39Y",
-      "xgzt2x+NCDhBxZ6EWkqXH6Xk5yOPUV8XDTjqwOnm4XvyD9jzxAiK9Bex6CxKNfph",
-      "9p42Kr3QZPVXjZofqcfhJxZ4Nv0s09K1R1yqNzMmO7Aa2uF2F6ChQ/m6Z41hdaeO",
-      "AxxsOeRYAlBFJ4oo2cFVyqkCAwEAAQ==",
-      "-----END PUBLIC KEY-----"
-    ],
-    "url": "https://pkg.trueos.org/pkg/freenas/12/unstable"
-  },
-  "ports": {
-    "branch": "freenas/12-stable",
-    "build": {
-      "default": []
-    },
-    "build-all": false,
-    "local_source":"/usr/local_source",
-    "make.conf": {
-      "default": [
-        "CRAZY=YES",
-        "DEFAULT_VERSIONS+=python=3.7",
-        "MAKE_JOBS_NUMBER_LIMIT=3",
-        "NET_SNMP_WITHOUT_MIB_MODULE_LIST=sctp-mib",
-	"WANT_OPENLDAP_SASL=YES",
-        "WITHOUT_CHECK=YES",
-        "editors_jed_UNSET+=X11",
-        "databases_rrdtool_UNSET+=DEJAVU",
-        "databases_rrdtool_UNSET+=PERL",
-        "databases_rrdtool_UNSET+=PYTHON",
-        "devel_dbus_UNSET+=X11",
-        "devel_gdb_SET+=PYTHON",
-        "dns_samba-nsupdate_SET+=IPV6",
-        "emulators_mtools_UNSET+=X11",
-        "emulators_openvm-tools_UNSET+=ICU",
-        "emulators_virtualbox-ose-kmod_SET+=VIMAGE",
-        "editors_jed_UNSET+=X11",
-        "devel_gdb_SET+=PYTHON",
-        "graphics_cairo_UNSET+=OPENGL XCB X11",
-        "lang_perl5.26_UNSET+=DTRACE",
-        "lang_python27_UNSET+=NLS",
-        "misc_mc_UNSET+=X11",
-        "net_netatalk3_SET+=ACL",
-        "net_netatalk3_SET+=DBUS",
-        "net_netatalk3_SET+=KERBEROS",
-        "net_netatalk3_SET+=KERBEROS5",
-        "net_netatalk3_SET+=LDAP",
-        "net_netatalk3_SET+=MDNSRESPONDER",
-        "net_netatalk3_SET+=SENDFILE",
-        "net_netatalk3_UNSET+=AVAHI",
-        "net_nss-pam-ldap-sasl_SET+=KERBEROS",
-        "net_nss-pam-ldap-sasl_SET+=NSS",
-        "net_nss-pam-ldap-sasl_SET+=PAM",
-        "net_py-ldap_SET+=SASL",
-        "net_rsync_SET+=ACL",
-        "net_rsync_SET+=ICONV",
-        "net_rsync_UNSET+=FLAGS",
-        "net_samba49_SET+=ACL_SUPPORT",
-        "net_samba49_SET+=AD_DC",
-        "net_samba49_SET+=ADS",
-        "net_samba49_SET+=AIO_SUPPORT",
-        "net_samba49_SET+=CLUSTER",
-        "net_samba49_SET+=DNSUPDATE",
-        "net_samba49_SET+=DOCS",
-        "net_samba49_SET+=EXP_MODULES",
-        "net_samba49_SET+=FAM",
-        "net_samba49_SET+=LDAP",
-        "net_samba49_SET+=LIBZFS",
-        "net_samba49_SET+=MDNSRESPONDER",
-        "net_samba49_SET+=NSUPDATE",
-        "net_samba49_SET+=PAM_SMBPASS",
-        "net_samba49_SET+=PTHREADPOOL",
-        "net_samba49_SET+=QUOTAS",
-        "net_samba49_SET+=SYSLOG",
-        "net_samba49_SET+=UTMP",
-        "net_samba49_UNSET+=AVAHI",
-        "net_samba49_UNSET+=BIND99",
-        "net_samba49_UNSET+=BIND910",
-        "net_samba49_UNSET+=CUPS",
-        "net_samba49_UNSET+=DEBUG",
-        "net_samba49_UNSET+=DEVELOPER",
-        "net_samba49_UNSET+=SPOTLIGHT",
-        "net-mgmt_net-snmp_UNSET+=PERL",
-        "net-mgmt_net-snmp_UNSET+=PERL_EMBEDDED",
-        "net-mgmt_collectd5_SET+=CURL",
-        "net-mgmt_collectd5_SET+=DISK",
-        "net-mgmt_collectd5_SET+=IPMI",
-        "net-mgmt_collectd5_SET+=NUTUPS",
-        "net-mgmt_collectd5_SET+=PYTHON",
-        "net-mgmt_collectd5_SET+=RRDTOOL",
-        "net-mgmt_collectd5_SET+=STATGRAB",
-        "net-mgmt_collectd5_UNSET+=BIND",
-        "net-mgmt_collectd5_UNSET+=SNMP",
-	"os_buildworld_UNSET+=BLUETOOTH",
-	"os_buildworld_UNSET+=BSDINSTALL",
-	"os_buildworld_UNSET+=PPP",
-	"os_buildworld_UNSET+=SVNLITE",
-        "security_openssh-portable_SET+=HEIMDIAL_BASE",
-        "security_openssh-portable_SET+=NONECIPHER",
-        "security_openssh-portable_SET+=HPN",
-        "security_sssd_SET+=SMB",
-        "security_sssd_UNSET+=DOCS",
-        "security_sudo_SET+=LDAP SSSD",
-        "shells_bash_UNSET+=NLS",
-        "shells_scponly_SET+=GFTP",
-        "shells_scponly_SET+=RSYNC",
-        "shells_scponly_SET+=SCP",
-        "shells_scponly_SET+=WINSCP",
-        "sysutils_e2fsprogs_UNSET+=NOTESTS",
-        "sysutils_e2fsprogs_SET+=SMALLTESTS",
-        "sysutils_nut_UNSET+=NEON",
-        "sysutils_tmux_SET+=LIBEVENT2",
-        "www_nginx_SET+=HTTP_SSL",
-        "www_nginx_SET+=HTTP_UPLOAD",
-        "www_nginx_SET+=HTTP_UPLOAD_PROGRESS",
-        "www_nginx_SET+=SPDY",
-        "www_nginx_SET+=STATUS",
-        "www_node_UNSET+=DTRACE",
-        "x11-toolkits_cairo_UNSET+=X11"
-      ]
-    },
-    "type": "git",
-    "url": "https://github.com/trueos/trueos-ports"
-  },
-  "poudriere-conf": [
-    "NOHANG_TIME=14400",
-    "BUILD_AS_NON_ROOT=no",
-    "RESTRICT_NETWORKING=no"
-  ],
-  "version": "1.1"
+	"base-packages": {
+		"kernel-flags": {
+			"default": [
+				"KERNCONF=IXNAS"
+			]
+		}
+	},
+	"poudriere": {
+		"jailname": "freenas",
+		"portsname": "freenas"
+	},
+	"iso": {
+		"auto-install-packages": {
+			"default": [
+				"freenas/freenas"
+			]
+		},
+		"auto-install-script": "",
+		"dist-packages": {},
+		"prune": {
+			"default": [
+				"METALOG",
+				"/usr/local/share/examples",
+				"/usr/local/include",
+				"/usr/bin/cc*",
+				"/usr/bin/clang*",
+				"/usr/bin/cpp",
+				"/usr/bin/cpp",
+				"/usr/bin/c++",
+				"/usr/bin/lldb",
+				"/usr/bin/ld.lld",
+				"/usr/bin/llvm*",
+				"/usr/bin/objdump*",
+				"/usr/bin/svn*",
+				"/usr/lib/clang",
+				"/usr/share/man",
+				"/usr/share/i18n",
+				"/usr/share/openssl/man",
+				"/usr/include",
+				"/usr/lib32"
+			]
+		},
+		"file-name": "FreeNAS-12-unstable-x64-%%DATE%%",
+		"install-script": "",
+		"iso-packages": {
+			"default": []
+		},
+		"offline-update": true,
+		"overlay": {},
+		"pool": {
+			"name": "freenas-boot"
+		},
+		"os_name": "FreeNAS",
+		"post-install-commands": [
+			{
+				"chroot": true,
+				"command": "sysrc -f /boot/loader.conf rc_system=rc"
+			},
+			{
+				"chroot": true,
+				"command": "touch /etc/dynamicdiskless"
+			},
+			{
+				"chroot": true,
+				"command": "mkdir -p /conf/base/etc"
+			},
+			{
+				"chroot": true,
+				"command": "echo 65535 > /conf/base/etc/md_size"
+			},
+			{
+				"chroot": true,
+				"command": "mkdir -p /conf/base/var"
+			},
+			{
+				"chroot": true,
+				"command": "mkdir -p /conf/base/mnt"
+			},
+			{
+				"chroot": true,
+				"command": "echo 8192 > /conf/base/mnt/md_size"
+			},
+			{
+				"chroot": true,
+				"command": "mkdir -p /conf/base/usr__local__etc"
+			},
+			{
+				"chroot": true,
+				"command": "echo 65535 > /conf/base/usr__local__etc/md_size"
+			},
+			{
+				"chroot": true,
+				"command": "ln -s /usr/local/etc /etc/local"
+			},
+			{
+				"chroot": true,
+				"command": "ln -fs /var/tmp/.rnd /.rnd"
+			},
+			{
+				"chroot": false,
+				"command": "zfs destroy freenas-boot/tmp"
+			},
+			{
+				"chroot": true,
+				"command": "rm -rf /tmp"
+			},
+			{
+				"chroot": true,
+				"command": "ln -fs /var/tmp /tmp"
+			}
+		]
+	},
+	"os_name": "FreeNAS",
+	"os_version": "12-STABLE",
+	"pkg-repo": {
+		"pubKey": [
+			"-----BEGIN PUBLIC KEY-----",
+			"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAx4YxSavJkE7HjopkMtgK",
+			"tk/plcnImzfx0MmdK3ijv2724+v810kbAmRI01aiooQvusfcQ5OOyNpAzxwKMTTB",
+			"6bo46YtrnYBTP5G1mNqTRxL5Sg03Kpwcb6fCZ4gYOqTNPmhV6BskhRrfGOzNazcd",
+			"cb8CeqTeL7A44vwkyufQrSNgT9+ByCGuxaEp2os+GEbELyWZMmpQD6s2gAgpXuB6",
+			"K/f7pm9ZsULjJ+ZKc31TjgMTyVA07niocjDxiD2KVEbiagirnxA7BLa66u58B1ol",
+			"tnvOD8JNkGONT2LJhWOMXowZ8fCQ6Ec6ws2SY0UJ14d4w7xnz7U9+STHRYlJnNyl",
+			"ZYNLZ7UK7zyILWhAjkmq3TUaw7o456+QIyf4hA/he9UZhwhgRGNjJCUATbEUT+PF",
+			"65ox6+rT5g/jjDlY6kxfvLCTYJG/Arlj9FCAV/vBa/0lUu1OjivxPNK694G4tVHl",
+			"/z1yApzgzbOgkOY1caPCkGgniD2N4rySm744RxVXonrKmso9nsG0tGrDTC72M39Y",
+			"xgzt2x+NCDhBxZ6EWkqXH6Xk5yOPUV8XDTjqwOnm4XvyD9jzxAiK9Bex6CxKNfph",
+			"9p42Kr3QZPVXjZofqcfhJxZ4Nv0s09K1R1yqNzMmO7Aa2uF2F6ChQ/m6Z41hdaeO",
+			"AxxsOeRYAlBFJ4oo2cFVyqkCAwEAAQ==",
+			"-----END PUBLIC KEY-----"
+		],
+		"url": "https://pkg.trueos.org/pkg/freenas/12/unstable"
+	},
+	"ports": {
+		"branch": "freenas/12-stable",
+		"build": {
+			"default": []
+		},
+		"build-all": false,
+		"local_source": "/usr/local_source",
+		"make.conf": {
+			"default": [
+				"CRAZY=YES",
+				"DEFAULT_VERSIONS+=python=3.7",
+				"MAKE_JOBS_NUMBER_LIMIT=3",
+				"NET_SNMP_WITHOUT_MIB_MODULE_LIST=sctp-mib",
+				"WANT_OPENLDAP_SASL=YES",
+				"WITHOUT_CHECK=YES",
+				"editors_jed_UNSET+=X11",
+				"databases_rrdtool_UNSET+=DEJAVU",
+				"databases_rrdtool_UNSET+=PERL",
+				"databases_rrdtool_UNSET+=PYTHON",
+				"devel_dbus_UNSET+=X11",
+				"devel_gdb_SET+=PYTHON",
+				"dns_samba-nsupdate_SET+=IPV6",
+				"emulators_mtools_UNSET+=X11",
+				"emulators_openvm-tools_UNSET+=ICU",
+				"emulators_virtualbox-ose-kmod_SET+=VIMAGE",
+				"editors_jed_UNSET+=X11",
+				"devel_gdb_SET+=PYTHON",
+				"graphics_cairo_UNSET+=OPENGL XCB X11",
+				"lang_perl5.26_UNSET+=DTRACE",
+				"lang_python27_UNSET+=NLS",
+				"misc_mc_UNSET+=X11",
+				"net_netatalk3_SET+=ACL",
+				"net_netatalk3_SET+=DBUS",
+				"net_netatalk3_SET+=KERBEROS",
+				"net_netatalk3_SET+=KERBEROS5",
+				"net_netatalk3_SET+=LDAP",
+				"net_netatalk3_SET+=MDNSRESPONDER",
+				"net_netatalk3_SET+=SENDFILE",
+				"net_netatalk3_UNSET+=AVAHI",
+				"net_nss-pam-ldap-sasl_SET+=KERBEROS",
+				"net_nss-pam-ldap-sasl_SET+=NSS",
+				"net_nss-pam-ldap-sasl_SET+=PAM",
+				"net_py-ldap_SET+=SASL",
+				"net_rsync_SET+=ACL",
+				"net_rsync_SET+=ICONV",
+				"net_rsync_UNSET+=FLAGS",
+				"net_samba49_SET+=ACL_SUPPORT",
+				"net_samba49_SET+=AD_DC",
+				"net_samba49_SET+=ADS",
+				"net_samba49_SET+=AIO_SUPPORT",
+				"net_samba49_SET+=CLUSTER",
+				"net_samba49_SET+=DNSUPDATE",
+				"net_samba49_SET+=DOCS",
+				"net_samba49_SET+=EXP_MODULES",
+				"net_samba49_SET+=FAM",
+				"net_samba49_SET+=LDAP",
+				"net_samba49_SET+=LIBZFS",
+				"net_samba49_SET+=MDNSRESPONDER",
+				"net_samba49_SET+=NSUPDATE",
+				"net_samba49_SET+=PAM_SMBPASS",
+				"net_samba49_SET+=PTHREADPOOL",
+				"net_samba49_SET+=QUOTAS",
+				"net_samba49_SET+=SYSLOG",
+				"net_samba49_SET+=UTMP",
+				"net_samba49_UNSET+=AVAHI",
+				"net_samba49_UNSET+=BIND99",
+				"net_samba49_UNSET+=BIND910",
+				"net_samba49_UNSET+=CUPS",
+				"net_samba49_UNSET+=DEBUG",
+				"net_samba49_UNSET+=DEVELOPER",
+				"net_samba49_UNSET+=SPOTLIGHT",
+				"net-mgmt_net-snmp_UNSET+=PERL",
+				"net-mgmt_net-snmp_UNSET+=PERL_EMBEDDED",
+				"net-mgmt_collectd5_SET+=CURL",
+				"net-mgmt_collectd5_SET+=DISK",
+				"net-mgmt_collectd5_SET+=IPMI",
+				"net-mgmt_collectd5_SET+=NUTUPS",
+				"net-mgmt_collectd5_SET+=PYTHON",
+				"net-mgmt_collectd5_SET+=RRDTOOL",
+				"net-mgmt_collectd5_SET+=STATGRAB",
+				"net-mgmt_collectd5_UNSET+=BIND",
+				"net-mgmt_collectd5_UNSET+=SNMP",
+				"os_buildworld_UNSET+=BLUETOOTH",
+				"os_buildworld_UNSET+=BSDINSTALL",
+				"os_buildworld_UNSET+=PPP",
+				"os_buildworld_UNSET+=SVNLITE",
+				"security_openssh-portable_SET+=HEIMDIAL_BASE",
+				"security_openssh-portable_SET+=NONECIPHER",
+				"security_openssh-portable_SET+=HPN",
+				"security_sssd_SET+=SMB",
+				"security_sssd_UNSET+=DOCS",
+				"security_sudo_SET+=LDAP SSSD",
+				"shells_bash_UNSET+=NLS",
+				"shells_scponly_SET+=GFTP",
+				"shells_scponly_SET+=RSYNC",
+				"shells_scponly_SET+=SCP",
+				"shells_scponly_SET+=WINSCP",
+				"sysutils_e2fsprogs_UNSET+=NOTESTS",
+				"sysutils_e2fsprogs_SET+=SMALLTESTS",
+				"sysutils_nut_UNSET+=NEON",
+				"sysutils_tmux_SET+=LIBEVENT2",
+				"www_nginx_SET+=HTTP_SSL",
+				"www_nginx_SET+=HTTP_UPLOAD",
+				"www_nginx_SET+=HTTP_UPLOAD_PROGRESS",
+				"www_nginx_SET+=SPDY",
+				"www_nginx_SET+=STATUS",
+				"www_node_UNSET+=DTRACE",
+				"x11-toolkits_cairo_UNSET+=X11"
+			]
+		},
+		"type": "git",
+		"url": "https://github.com/trueos/trueos-ports"
+	},
+	"poudriere-conf": [
+		"NOHANG_TIME=14400",
+		"BUILD_AS_NON_ROOT=no",
+		"RESTRICT_NETWORKING=no"
+	],
+	"version": "1.1"
 }


### PR DESCRIPTION
This commit updates FreeNAS 12 manifest to make use of the freenas meta port which we will use now to take care of all the related dependencies.
Ticket: #74667