### PR TITLE
[change] Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Use the package repository to assemble a pre-installed VM image.
 
 **Output Logs:** release/vm-logs
 
+Optional inputs (environment variables):
+* **VMPOOLNAME** : Create/use a temporary ZFS pool with this name for the VM build environment.
+   * Default Value: "vm-gen-pool"
+ 
 # License
 BSD 2 Clause
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ This selection will get saved to the local ".config/manifest" file and used when
 ### make ports
 Build all of the OS and ports and assemble a package repository.
 
-**Output Directory:** /usr/obj/???
+**Output Directory:** release/packages
+
+**Output Logs:** release/port-logs, release/src-logs
 
 Optional inputs (environment variables):
 * **POUDRIERE_BASEFS** : This is the path to the poudriere working directory ("/usr/local/poudriere" by default)
@@ -52,23 +54,27 @@ Optional inputs (environment variables):
 
 ### make iso
 Use the package repository to assemble an ISO (hybrid DVD/USB image).
+
 **Note:** For any "*.iso" file that is created, this process will also generate *.sha256 and *.md5 checksum files as well.
 
 **Output Directory:** release/iso
-**Output Logs:** release/iso-logs/*.log
+
+**Output Logs:** release/iso-logs
 
 Optional inputs (environment variables):
 * *TO-DO*
 
 ### make vm
 Use the package repository to assemble a pre-installed VM image.
+
 **Note:** For any "*.img" file that is created, this process will also generate *.sha256 and *.md5 checksum files as well.
 
 **Output Directory:** release/vm
 
+**Output Logs:** release/vm-logs
+
 # License
-----
 BSD 2 Clause
 
-
+----
 *This documentation was provided by Ken Moore from the [Project Trident](https://project-trident.org) distribution of TrueOS*

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This command will clean up:
 
 ### make config
 This will launch an interactive prompt to select a build manifest from the example files in the [manifests directory](https://github.com/trueos/build/tree/master/manifests) and use that as the default build manifest.
-This selection will get saved to the local ".config/manifest" file and used whenever the **TRUEOS_MANIFEST** environment variable is not set. This command may be run whenever a change your default manifest is desired.
+The selected Manifest name will get saved to the local ".config/manifest" file and used whenever the **TRUEOS_MANIFEST** environment variable is not set. This command may be run whenever a different default manifest is desired.
 
 **WARNING:** If no build manifest is specified (either by running `make config` or providing the TRUEOS_MANIFEST environment variable), then the "trueos-snapshot.json" build manifest will be used automatically from the [manifests directory](https://github.com/trueos/build/tree/master/manifests).
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,67 @@ TrueOS Build repo is a JSON manifest-based build system for TrueOS. It uses poud
  - Installed textproc/jq package
  - Configured /usr/local/etc/poudriere.conf (I.E. to setup ZPOOL)
 
-# Usage
+# Build Manifest
+TrueOS uses a single JSON configuration file as a "build manifest" containing all the instructions and/or specifications for building the distribution. For details about the build manifests, please refer to the [manifests directory](https://github.com/trueos/build/tree/master/manifests) for information about creating a build manifest as well as example manifest files.
 
+A build manifest can be supplied for the build in a couple of different ways:
+1. Set the "TRUEOS_MANIFEST" environment variable to the absolute path to the desired build manifest file.
+2. Run `make config` to select from one of the available build manifests in the [manifests directory](https://github.com/trueos/build/tree/master/manifests).
+
+# Usage
+Standard commands to build a TrueOS distribution:
 ```
 # make ports
 # make iso
 ```
 
-License
-----
+## All Options
 
+### make clean
+This command will clean up files from previous builds. Running this command is typically not required by the user, as the individual cleaning operations are dynamically run as needed during a build procedure so that the current build is not negatively impacted by previous build artifacts.
+
+This command will clean up:
+
+* Poudriere jails, ports trees, and mountpoints.
+* ISO output directory : Deleting the output of any "make iso" commands run previously.
+* VM output directory : Deleting the output of any "make vm" commands run previously.
+
+### make config
+This will launch an interactive prompt to select a build manifest from the example files in the [manifests directory](https://github.com/trueos/build/tree/master/manifests) and use that as the default build manifest.
+This selection will get saved to the local ".config/manifest" file and used whenever the **TRUEOS_MANIFEST** environment variable is not set. This command may be run whenever a change your default manifest is desired.
+
+**WARNING:** If no build manifest is specified (either by running `make config` or providing the TRUEOS_MANIFEST environment variable), then the "trueos-snapshot.json" build manifest will be used automatically from the [manifests directory](https://github.com/trueos/build/tree/master/manifests).
+
+### make ports
+Build all of the OS and ports and assemble a package repository.
+
+**Output Directory:** /usr/obj/???
+
+Optional inputs (environment variables):
+* **POUDRIERE_BASEFS** : This is the path to the poudriere working directory ("/usr/local/poudriere" by default)
+* **SIGNING_KEY** : This is the private key which should be used to sign the packages once they are built.
+* **LOCAL_SOURCE_DIR** : Location of any additional source files which need to be copied into the OS source tree (source tree overlay).
+   * Default value: "source"
+
+### make iso
+Use the package repository to assemble an ISO (hybrid DVD/USB image).
+**Note:** For any "*.iso" file that is created, this process will also generate *.sha256 and *.md5 checksum files as well.
+
+**Output Directory:** release/iso
+**Output Logs:** release/iso-logs/*.log
+
+Optional inputs (environment variables):
+* *TO-DO*
+
+### make vm
+Use the package repository to assemble a pre-installed VM image.
+**Note:** For any "*.img" file that is created, this process will also generate *.sha256 and *.md5 checksum files as well.
+
+**Output Directory:** release/vm
+
+# License
+----
 BSD 2 Clause
+
+
+*This documentation was provided by Ken Moore from the [Project Trident](https://project-trident.org) distribution of TrueOS*

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ TrueOS uses a single JSON configuration file as a "build manifest" containing al
 A build manifest can be supplied for the build in a couple of different ways:
 1. Set the "TRUEOS_MANIFEST" environment variable to the absolute path to the desired build manifest file.
 2. Run `make config` to select from one of the available build manifests in the [manifests directory](https://github.com/trueos/build/tree/master/manifests).
-3. Do nothing and automatically use the default build manifest (trueos-snapshot). 
-   * NOTE: The trueos-snapshot manifest only builds a tiny subset of packages and is primarily used for testing the build procedures and base OS packages only.
+3. Do nothing and automatically use the default build manifest (trueos-snapshot-builder). 
+   * NOTE: The trueos-snapshot-builder manifest only builds a tiny subset of packages and is primarily used for testing the build procedures and base OS packages only.
 
 # Usage
 Standard commands to build a TrueOS distribution:
@@ -38,8 +38,6 @@ This command will clean up:
 ### make config
 This will launch an interactive prompt to select a build manifest from the example files in the [manifests directory](https://github.com/trueos/build/tree/master/manifests) and use that as the default build manifest.
 The selected Manifest name will get saved to the local ".config/manifest" file and used whenever the **TRUEOS_MANIFEST** environment variable is not set. This command may be run whenever a different default manifest is desired.
-
-**WARNING:** If no build manifest is specified (either by running `make config` or providing the TRUEOS_MANIFEST environment variable), then the "trueos-snapshot.json" build manifest will be used automatically from the [manifests directory](https://github.com/trueos/build/tree/master/manifests).
 
 ### make ports
 Assemble packages for the OS and any ports listed in the build manifest. These packages will be automatically treated as  a full repository for use as needed.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The selected Manifest name will get saved to the local ".config/manifest" file a
 **WARNING:** If no build manifest is specified (either by running `make config` or providing the TRUEOS_MANIFEST environment variable), then the "trueos-snapshot.json" build manifest will be used automatically from the [manifests directory](https://github.com/trueos/build/tree/master/manifests).
 
 ### make ports
-Build all of the OS and ports and assemble a package repository.
+Assemble packages for the OS and any ports listed in the build manifest. These packages will be automatically treated as  a full repository for use as needed.
 
 **Output Directory:** release/packages
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ TrueOS uses a single JSON configuration file as a "build manifest" containing al
 A build manifest can be supplied for the build in a couple of different ways:
 1. Set the "TRUEOS_MANIFEST" environment variable to the absolute path to the desired build manifest file.
 2. Run `make config` to select from one of the available build manifests in the [manifests directory](https://github.com/trueos/build/tree/master/manifests).
+3. Do nothing and automatically use the default build manifest (trueos-snapshot). 
+   * NOTE: The trueos-snapshot manifest only builds a tiny subset of packages and is primarily used for testing the build procedures and base OS packages only.
 
 # Usage
 Standard commands to build a TrueOS distribution:

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -14,20 +14,24 @@ This document corresponds to version "1.1", so any manifest using this specifica
 ### Distribution Branding
 There are a couple options which may be set in the manifest in order to "brand" the distribution of TrueOS.
 
-* "os_name" (string) : Branding name for the distribution.
+* **os_name** (string) : Branding name for the distribution.
    * Default Value: "TrueOS"
    * Will change the branding in pc-installdialog, and the distro branding in the bootloader as well.
-* "os_version" (string) : Custom version tag for the build. 
+* **os_version** (string) : Custom version tag for the build. 
    * At build time this will become the "TRUEOS_VERSION" environment variable which can be used in filename expansions and such later (if that environment variable is not already set).
 
+### base-packages
+The "base-packages" target allows the configuration of the OS packages itself. This can involve the naming scheme, build flags, extra dependencies, and more.
+
+
 #### Base Packages Options
-* "name-prefix" (string) : Naming convention for the base packages (Example: FreeBSD-runtime will become [name-prefix]-runtime)
-* "depends" (JSON object) : This is a object containing declarations of additional dependencies that you would like to add to particular base packages: The next level of the object is the name of the base package, then within that object is the name of the package you want to add as a dependency, and within that is the origin and version of the package that is needed. See the example below for a working demonstration of this dependency injection.
+* **name-prefix** (string) : Naming convention for the base packages (Example: FreeBSD-runtime will become [name-prefix]-runtime)
+* **depends** (JSON object) : This is a object containing declarations of additional dependencies that you would like to add to particular base packages: The next level of the object is the name of the base package, then within that object is the name of the package you want to add as a dependency, and within that is the origin and version of the package that is needed. See the example below for a working demonstration of this dependency injection.
    * **WARNING:** Make sure that only simple ports/packages are injected with this mechanism! Example: The runtime package installs the user/groups files on the system, so adding a dependency on a package that needs to create a user/group will cause install failures since the dependency is installed before the runtime package.
-* "kernel-flags" and "world-flags" (JSON object) : These are objects containing extra builds flags that will be used for the kernel/world build stages. 
-   * "default" (JSON array of strings) : Default list of build flags (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* "strip-plist" (JSON array of strings) :  List of directories or files that need to be removed from the base-packages.
+* **kernel-flags** and **world-flags** (JSON object) : These are objects containing extra builds flags that will be used for the kernel/world build stages. 
+   * **default** (JSON array of strings) : Default list of build flags (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* **strip-plist** (JSON array of strings) :  List of directories or files that need to be removed from the base-packages.
 
 #### Base Packages Example
 ```
@@ -72,45 +76,45 @@ There are a couple options which may be set in the manifest in order to "brand" 
 The "iso" target within the manifest controls all the options specific to creation/setup of the ISO image. This can involve setting a custom install script, choosing packages which need to be installed or available for installation on the ISO, and more.
 
 #### ISO Options
-* "file-name" (string): Template for the generation of the ISO filename. There are a few format options which can be auto-populated:
-   * "%%TRUEOS_VERSION%%" : Replace this field with the value of the TRUEOS_VERSION environment variable.
-   * "%%GITHASH%%" : (Requires sources to be cloned with git) Replace this field with the hash of the latest git commit.
-   * "%%DATE%%" : Replace this field with the date that the ISO was generated (YYYYMMDD)'
-* "install-script" (string): Tool to automatically launch when booting the ISO (default: `pc-sysinstaller`)
-* "auto-install-script" (string): Path to config file for `pc-sysinstall` to perform an unattended installation.
-* "post-install-commands" (JSON array of objects) : Additional commands to run after an installation with pc-sysinstaller (not used for custom install scripts).
-   * "chroot" (boolian) : Run command within the newly-installed system (true) or on the ISO itself (false)
-   * "command" (string) : Command to run
-* "prune" (JSON object) : Lists of files or directories to remove from the ISO
-   * "default" (JSON array of strings) : Default list (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* "dist-packages" (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO
-   * "default" (JSON array of strings) : Default list (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* "offline-update" (boolian) : If set to true will generate a system-update.img file containing ISOs dist files
-* "optional-dist-packages" (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO. These ones are considered "optional" and may or may not be included depending on whether the package built successfully.
-   * "default" (JSON array of strings) : Default list (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* "pool" (JSON object) : Settings for boot pool
- * "name" (string) : Default name of ZFS boot pool
-* "prune-dist-packages" (JSON object) : Lists of *regular expressions* to use to find and remove dist packages. This is useful for forcibly removing particular types of base packages.
+* **file-name** (string): Template for the generation of the ISO filename. There are a few format options which can be auto-populated:
+   * **%%TRUEOS_VERSION%%** : Replace this field with the value of the TRUEOS_VERSION environment variable.
+   * **%%GITHASH%%** : (Requires sources to be cloned with git) Replace this field with the hash of the latest git commit.
+   * **%%DATE%%** : Replace this field with the date that the ISO was generated (YYYYMMDD)'
+* **install-script** (string): Tool to automatically launch when booting the ISO (default: `pc-sysinstaller`)
+* **auto-install-script** (string): Path to config file for `pc-sysinstall` to perform an unattended installation.
+* **post-install-commands** (JSON array of objects) : Additional commands to run after an installation with pc-sysinstaller (not used for custom install scripts).
+   * **chroot** (boolian) : Run command within the newly-installed system (true) or on the ISO itself (false)
+   * **command** (string) : Command to run
+* **prune** (JSON object) : Lists of files or directories to remove from the ISO
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* **dist-packages** (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* **offline-update** (boolian) : If set to true will generate a system-update.img file containing ISOs dist files
+* **optional-dist-packages** (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO. These ones are considered "optional" and may or may not be included depending on whether the package built successfully.
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* **pool** (JSON object) : Settings for boot pool
+ * **name** (string) : Default name of ZFS boot pool
+* **prune-dist-packages** (JSON object) : Lists of *regular expressions* to use to find and remove dist packages. This is useful for forcibly removing particular types of base packages.
    * Note: The regular expression support is shell based (grep -E "expression"). Lookahead and look
-   * "default" (JSON array of strings) : Default list (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* "iso-packages" (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
-   * "default" (JSON array of strings) : Default list (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* "ignore-base-packages" (JSON array of strings) : List of base packages to ignore when installing base packages into the ISO. 
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* **iso-packages** (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* **ignore-base-packages** (JSON array of strings) : List of base packages to ignore when installing base packages into the ISO. 
    * This is turned into a regex automatically, so "-clang-" will remove all forms of the clang package, but "-clang-development" will only ignore the development package for clang.
    * **WARNING** Do *NOT* ignore the "runtime" package - this will typically break the ability of the ISO to start up.
-* "auto-install-packages" (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer.
+* **auto-install-packages** (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer.
    * **NOTE:** These packages will automatically get added to the "dist-packages" available on the ISO as well.
-   * "default" (JSON array of strings) : Default list (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* "overlay" (JSON object) : Overlay files or directories to be inserted into the ISO
-   * "type" (string) : One of the following options: [git, svn, tar, local]
-   * "branch" (string) : Branch of the repository to fetch (svn/git).
-   * "url" (string) : Url to the repository (svn/git), URL to fetch tar file (tar), or path to the directory (local)
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* **overlay** (JSON object) : Overlay files or directories to be inserted into the ISO
+   * **type** (string) : One of the following options: [git, svn, tar, local]
+   * **branch** (string) : Branch of the repository to fetch (svn/git).
+   * **url** (string) : Url to the repository (svn/git), URL to fetch tar file (tar), or path to the directory (local)
    
 #### ISO Example
 ```
@@ -192,18 +196,18 @@ The "iso" target within the manifest controls all the options specific to creati
 The "ports" target allows for configuring the build targets and options for the ports system. That can include changing the default version for particular packages, selecting a subset of packages to build, and more.
 
 #### Ports Options
-* "type" (string) : One of the following: [git, svn, tar, local, null]. Where to look for the ports tree.
-* "branch" (string) : Branch of the repository to use (svn/git only)
-* "url" (string) : URL to the repository (svn/git), where to fetch the tar file (tar), or path to directory (local)
-* "local_source" (string) : Path to a local directory where the ports tree should be placed (used for reproducible builds). This directory name will be visible in the output of `uname` on installed systems.
-* "build-all" (boolian) : Build the entire ports collection (true/false)
-* "build" (JSON object) : Lists of packages (by port origin) to build. If "build-all" is true, then this list will be treated as "essential" packages and if any of them fail to build properly then the entire build will be flagged as a failure.
-   * "default" (JSON array of strings) : Default list (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name is set
-* "make.conf" (JSON object) : Lists of build flags for use when building the ports.
-   * "default" (JSON array of strings) : Default list (required)
-   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name is set
-* "strip-plist" (JSON array of strings) : List of files or directories to remove from any packages that try to use them.
+* **type** (string) : One of the following: [git, svn, tar, local, null]. Where to look for the ports tree.
+* **branch** (string) : Branch of the repository to use (svn/git only)
+* **url** (string) : URL to the repository (svn/git), where to fetch the tar file (tar), or path to directory (local)
+* **local_source** (string) : Path to a local directory where the ports tree should be placed (used for reproducible builds). This directory name will be visible in the output of `uname` on installed systems.
+* **build-all** (boolian) : Build the entire ports collection (true/false)
+* **build** (JSON object) : Lists of packages (by port origin) to build. If "build-all" is true, then this list will be treated as "essential" packages and if any of them fail to build properly then the entire build will be flagged as a failure.
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name is set
+* **make.conf** (JSON object) : Lists of build flags for use when building the ports.
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name is set
+* **strip-plist** (JSON array of strings) : List of files or directories to remove from any packages that try to use them.
 
 #### Ports Example
 ```
@@ -243,20 +247,24 @@ The "ports" target allows for configuring the build targets and options for the 
 The "poudriere" object allows the configuration of the poudriere build system for individual build manifests, allowing many different builds to be performed on the same system without conflicting with each other.
 
 #### Poudriere Options
-* "jailname" (string) : Use this name internally for the jail which is used for the builds.
+* **jailname** (string) : Use this name internally for the jail which is used for the builds.
    * If not provided, the "trueos-mk-base" name will be used.
-* "portsname" (string) : Use this name internally for the ports tree used by the build.
+* **portsname** (string) : Use this name internally for the ports tree used by the build.
    * If not provided, the "trueos-mk-ports" name will be used.
 
-### base-packages
-The "base-packages" target allows the configuration of the OS packages itself. This can involve the naming scheme, build flags, extra dependencies, and more.
-
+#### Poudriere Example
+```
+"poudriere" : {
+  "jailname" : "my-distro-edge",
+  "portsname" : "edge"
+}
+```
 
 ### poudriere-conf
 This field contains a list of options to use to configure the poudriere instance that will build the packages. The configuration of poudriere is automatically performed to ensure an optimal result for most build systems, but it is possible to further customize these settings as needed.
 
 #### Poudriere-conf Options
-* "poudriere-conf" (JSON array of strings) : List of configuration options for poudriere
+* **poudriere-conf** (JSON array of strings) : List of configuration options for poudriere
 * */etc/poudriere.conf.release* - If this file exists on the system, it will be appended as a whole to the auto-generated config.
 
 Common options to configure:
@@ -299,11 +307,11 @@ PRIORITY_BOOST="pypy* openoffice* iridium* chromium*"
 As part of the build process, the packages can also be automatically assembled into a full package repository which may be used for providing access to the newly-build packages on other systems.
 
 #### pkg-repo Options
-* "pkg-repo-name" (string) : Short-name for the package repository (default: "TrueOS")
-* "pkg-train-name" (string) : Name for the package repository train used by sysutils/sysup (default: "TrueOS")
-* "pkg-repo" (JSON Object) : Settings for the unified base+ports package repo
-   * "url" (string) : Public URL where the repository can be found. (Distro creators will need to setup access for this URL and copy the pkg repo files as needed to make them available at the given location).
-   * "pubKey" (JSON Array of strings) : SSL public key to use when verifying integrity of downloaded packages (one line of test per item in the array). This is basically just the plain-text of the SSL public key file converted into an array of strings. 
+* **pkg-repo-name** (string) : Short-name for the package repository (default: "TrueOS")
+* **pkg-train-name** (string) : Name for the package repository train used by sysutils/sysup (default: "TrueOS")
+* **pkg-repo** (JSON Object) : Settings for the unified base+ports package repo
+   * **url** (string) : Public URL where the repository can be found. (Distro creators will need to setup access for this URL and copy the pkg repo files as needed to make them available at the given location).
+   * **pubKey** (JSON Array of strings) : SSL public key to use when verifying integrity of downloaded packages (one line of test per item in the array). This is basically just the plain-text of the SSL public key file converted into an array of strings. 
       * **WARNING** Make sure that this public key is the complement to the private key that you are using to sign the packages!!
    
 #### pkg-repo Example

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -174,6 +174,35 @@ The "iso" target within the manifest controls all the options specific to creati
 }
 ```
 
+### vm
+The "vm" target is used to provide custom settings when assembling a VM image with the `make vm` command.
+
+#### VM Options
+* **file-name** (string): Template for the generation of the IMG filename. There are a few format options which can be auto-populated:
+   * "%%TRUEOS_VERSION%%" : Replace this field with the value of the TRUEOS_VERSION environment variable.
+   * "%%GITHASH%%" : (Requires sources to be cloned with git) Replace this field with the hash of the latest git commit.
+   * "%%DATE%%" : Replace this field with the date that the image was generated (YYYYMMDD)'
+* **type** (string) : Custom type of VM to be used for additional setup procedures
+   * "ec2" : Ensure the VM is compatible with the Amazon EC2 specification.
+   * All other types are currently valid but do not trigger any custom configuration routines.
+* **size** (string) : Truncate the VM image file according to this option.
+   * This string is used as an argument to the "truncate -s [size] ...." command. 
+   * Please view the manual page for the "truncate" utility for additional information (`man truncate`).
+* **disk-config** (string) : Name of the disk configuration script to use from the [vm-diskcfg directory](https://github.com/trueos/build/master/vm-diskconfig).
+   * Example: a value of "zfs-noswap" will use the "vm-diskcfg/zfs-noswap.sh" disk configuration script to setup the VM.
+* **boot** (string) : Either "zfs" or "ufs". Use this filesystem for the VM image.
+
+#### VM Example
+```
+"vm" : {
+  "file-name" : "my-distro-EC2-%%TRUEOS_VERSION%%-%%DATE%%",
+  "type" : "ec2",
+  "size" : "3G",
+  "disk-config" : "zfs-noswap",
+  "boot" : "zfs"
+}
+```
+
 ### ports
 The "ports" target allows for configuring the build targets and options for the ports system. That can include changing the default version for particular packages, selecting a subset of packages to build, and more.
 

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -93,7 +93,7 @@ The "iso" target within the manifest controls all the options specific to creati
 * **iso-packages** (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* **auto-install-packages** (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer.
+* **auto-install-packages** (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer or when creating a VM image.
    * **NOTE:** These packages will automatically get added to the "dist-packages" available on the ISO as well.
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -25,27 +25,16 @@ The "base-packages" target allows the configuration of the OS packages itself. T
 
 
 #### Base Packages Options
-* **name-prefix** (string) : Naming convention for the base packages (Example: FreeBSD-runtime will become [name-prefix]-runtime)
-* **depends** (JSON object) : This is a object containing declarations of additional dependencies that you would like to add to particular base packages: The next level of the object is the name of the base package, then within that object is the name of the package you want to add as a dependency, and within that is the origin and version of the package that is needed. See the example below for a working demonstration of this dependency injection.
-   * **WARNING:** Make sure that only simple ports/packages are injected with this mechanism! Example: The runtime package installs the user/groups files on the system, so adding a dependency on a package that needs to create a user/group will cause install failures since the dependency is installed before the runtime package.
 * **kernel-flags** and **world-flags** (JSON object) : These are objects containing extra builds flags that will be used for the kernel/world build stages. 
-   * **default** (JSON array of strings) : Default list of build flags (required)
+   * **default** (JSON array of strings) : Default list of build flags (required if the object is defined)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+   * ***WARNING:*** The only kernel flag that should be optionally set here is the "KERNCONF" setting for selecting a custom kernel configuration. All other world/kernel options are exposed via port options on the "buildworld" and "buildkernel" ports and should be modified in the "ports -> make.conf" section of the manifest.
 * **strip-plist** (JSON array of strings) :  List of directories or files that need to be removed from the base-packages.
 
 #### Base Packages Example
 ```
 "base-packages" : {
-  "name-prefix" : "TrueOS",
-  "depends" : {
-    "runtime": {
-      "uclcmd": {
-        "origin": "devel/uclcmd",
-        "version": ">0"
-      }
-    }
-  },
-  "kernel-flags": {
+  "world-flags": {
     "default": [
       "WITH_FOO=1",
       "WITH_BAR=2"
@@ -55,7 +44,7 @@ The "base-packages" target allows the configuration of the OS packages itself. T
       "WITHOUT_FOOBAR2=1"
     ]
   },
-  "world-flags": {
+  "kernel-flags": {
     "default": [
       "WITH_FOO=1",
       "WITH_BAR=2"
@@ -77,9 +66,9 @@ The "iso" target within the manifest controls all the options specific to creati
 
 #### ISO Options
 * **file-name** (string): Template for the generation of the ISO filename. There are a few format options which can be auto-populated:
-   * **%%TRUEOS_VERSION%%** : Replace this field with the value of the TRUEOS_VERSION environment variable.
-   * **%%GITHASH%%** : (Requires sources to be cloned with git) Replace this field with the hash of the latest git commit.
-   * **%%DATE%%** : Replace this field with the date that the ISO was generated (YYYYMMDD)'
+   * "%%TRUEOS_VERSION%%" : Replace this field with the value of the TRUEOS_VERSION environment variable.
+   * "%%GITHASH%%" : (Requires sources to be cloned with git) Replace this field with the hash of the latest git commit.
+   * "%%DATE%%" : Replace this field with the date that the ISO was generated (YYYYMMDD)'
 * **install-script** (string): Tool to automatically launch when booting the ISO (default: `pc-sysinstaller`)
 * **auto-install-script** (string): Path to config file for `pc-sysinstall` to perform an unattended installation.
 * **post-install-commands** (JSON array of objects) : Additional commands to run after an installation with pc-sysinstaller (not used for custom install scripts).
@@ -304,15 +293,15 @@ PRIORITY_BOOST="pypy* openoffice* iridium* chromium*"
 ```
 
 ### pkg-repo
-As part of the build process, the packages can also be automatically assembled into a full package repository which may be used for providing access to the newly-build packages on other systems.
+This section determines the default package repository configuration for the installed system.
 
 #### pkg-repo Options
 * **pkg-repo-name** (string) : Short-name for the package repository (default: "TrueOS")
 * **pkg-train-name** (string) : Name for the package repository train used by sysutils/sysup (default: "TrueOS")
-* **pkg-repo** (JSON Object) : Settings for the unified base+ports package repo
+* **pkg-repo** (JSON Object) : Settings for the package repository
    * **url** (string) : Public URL where the repository can be found. (Distro creators will need to setup access for this URL and copy the pkg repo files as needed to make them available at the given location).
    * **pubKey** (JSON Array of strings) : SSL public key to use when verifying integrity of downloaded packages (one line of test per item in the array). This is basically just the plain-text of the SSL public key file converted into an array of strings. 
-      * **WARNING** Make sure that this public key is the complement to the private key that you are using to sign the packages!!
+      * **WARNING** Make sure that this public key is the complement to the private key which is used to sign the packages!!
    
 #### pkg-repo Example
 
@@ -329,4 +318,5 @@ As part of the build process, the packages can also be automatically assembled i
 }
 ```
 
+---
 *This documentation was provided by Ken Moore from the [Project Trident](https://project-trident.org) distribution of TrueOS*

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -93,9 +93,6 @@ The "iso" target within the manifest controls all the options specific to creati
 * **iso-packages** (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* **ignore-base-packages** (JSON array of strings) : List of base packages to ignore when installing base packages into the ISO. 
-   * This is turned into a regex automatically, so "-clang-" will remove all forms of the clang package, but "-clang-development" will only ignore the development package for clang.
-   * **WARNING** Do *NOT* ignore the "runtime" package - this will typically break the ability of the ISO to start up.
 * **auto-install-packages** (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer.
    * **NOTE:** These packages will automatically get added to the "dist-packages" available on the ISO as well.
    * **default** (JSON array of strings) : Default list (required)
@@ -139,10 +136,6 @@ The "iso" target within the manifest controls all the options specific to creati
       "/usr/local/include"
     ]
   },
-  "ignore-base-packages": [
-    "-clang-",
-    "-sendmail-"
-  ],
   "iso-packages": {
     "default": [
       "sysutils/ipmitool",
@@ -312,7 +305,7 @@ This section determines the default package repository configuration for the ins
   "url" : "http://pkg.trueos.org/pkg/release/${ABI}/latest",
   "pubKey : [
     "-----BEGIN PUBLIC KEY-----",
-    "sdigosbhdgiub+asdgilpubLIUYASVBfiGULiughlBHJljib"
+    "sdigosbhdgiub+asdgilpubLIUYASVBfiGULiughlBHJljib",
     "-----END PUBLIC KEY-----"
   ]
 }

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,324 @@
+# The Manifest File:
+--------------
+
+TrueOS includes several manifest files in this directory which may be referenced for examples of usable build manifests.
+which can be customized with the following JSON settings:
+
+### version
+The JSON manifest has a version control string which must be set. 
+
+This document corresponds to version "1.1", so any manifest using this specification needs to have the following field in the top-level object of the manifest:
+
+`"version" : "1.1"`
+
+### Distribution Branding
+There are a couple options which may be set in the manifest in order to "brand" the distribution of TrueOS.
+
+* "os_name" (string) : Branding name for the distribution.
+   * Default Value: "TrueOS"
+   * Will change the branding in pc-installdialog, and the distro branding in the bootloader as well.
+* "os_version" (string) : Custom version tag for the build. 
+   * At build time this will become the "TRUEOS_VERSION" environment variable which can be used in filename expansions and such later (if that environment variable is not already set).
+
+#### Base Packages Options
+* "name-prefix" (string) : Naming convention for the base packages (Example: FreeBSD-runtime will become [name-prefix]-runtime)
+* "depends" (JSON object) : This is a object containing declarations of additional dependencies that you would like to add to particular base packages: The next level of the object is the name of the base package, then within that object is the name of the package you want to add as a dependency, and within that is the origin and version of the package that is needed. See the example below for a working demonstration of this dependency injection.
+   * **WARNING:** Make sure that only simple ports/packages are injected with this mechanism! Example: The runtime package installs the user/groups files on the system, so adding a dependency on a package that needs to create a user/group will cause install failures since the dependency is installed before the runtime package.
+* "kernel-flags" and "world-flags" (JSON object) : These are objects containing extra builds flags that will be used for the kernel/world build stages. 
+   * "default" (JSON array of strings) : Default list of build flags (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "strip-plist" (JSON array of strings) :  List of directories or files that need to be removed from the base-packages.
+
+#### Base Packages Example
+```
+"base-packages" : {
+  "name-prefix" : "TrueOS",
+  "depends" : {
+    "runtime": {
+      "uclcmd": {
+        "origin": "devel/uclcmd",
+        "version": ">0"
+      }
+    }
+  },
+  "kernel-flags": {
+    "default": [
+      "WITH_FOO=1",
+      "WITH_BAR=2"
+    ],
+    "ENV_VARIABLE_FOOBAR": [
+      "WITH_FOOBAR=1",
+      "WITHOUT_FOOBAR2=1"
+    ]
+  },
+  "world-flags": {
+    "default": [
+      "WITH_FOO=1",
+      "WITH_BAR=2"
+    ],
+    "ENV_VARIABLE_FOOBAR": [
+      "WITH_FOOBAR=1",
+      "WITHOUT_FOOBAR2=1"
+    ]
+  },
+  "strip-plist":[
+	  "/usr/share/examples/pc",
+	  "/usr/share/examples/ppp"
+  ]
+}
+```
+
+### iso
+The "iso" target within the manifest controls all the options specific to creation/setup of the ISO image. This can involve setting a custom install script, choosing packages which need to be installed or available for installation on the ISO, and more.
+
+#### ISO Options
+* "file-name" (string): Template for the generation of the ISO filename. There are a few format options which can be auto-populated:
+   * "%%TRUEOS_VERSION%%" : Replace this field with the value of the TRUEOS_VERSION environment variable.
+   * "%%GITHASH%%" : (Requires sources to be cloned with git) Replace this field with the hash of the latest git commit.
+   * "%%DATE%%" : Replace this field with the date that the ISO was generated (YYYYMMDD)'
+* "install-script" (string): Tool to automatically launch when booting the ISO (default: `pc-sysinstaller`)
+* "auto-install-script" (string): Path to config file for `pc-sysinstall` to perform an unattended installation.
+* "post-install-commands" (JSON array of objects) : Additional commands to run after an installation with pc-sysinstaller (not used for custom install scripts).
+   * "chroot" (boolian) : Run command within the newly-installed system (true) or on the ISO itself (false)
+   * "command" (string) : Command to run
+* "prune" (JSON object) : Lists of files or directories to remove from the ISO
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "dist-packages" (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "offline-update" (boolian) : If set to true will generate a system-update.img file containing ISOs dist files
+* "optional-dist-packages" (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO. These ones are considered "optional" and may or may not be included depending on whether the package built successfully.
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "pool" (JSON object) : Settings for boot pool
+ * "name" (string) : Default name of ZFS boot pool
+* "prune-dist-packages" (JSON object) : Lists of *regular expressions* to use to find and remove dist packages. This is useful for forcibly removing particular types of base packages.
+   * Note: The regular expression support is shell based (grep -E "expression"). Lookahead and look
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "iso-packages" (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "ignore-base-packages" (JSON array of strings) : List of base packages to ignore when installing base packages into the ISO. 
+   * This is turned into a regex automatically, so "-clang-" will remove all forms of the clang package, but "-clang-development" will only ignore the development package for clang.
+   * **WARNING** Do *NOT* ignore the "runtime" package - this will typically break the ability of the ISO to start up.
+* "auto-install-packages" (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer.
+   * **NOTE:** These packages will automatically get added to the "dist-packages" available on the ISO as well.
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* "overlay" (JSON object) : Overlay files or directories to be inserted into the ISO
+   * "type" (string) : One of the following options: [git, svn, tar, local]
+   * "branch" (string) : Branch of the repository to fetch (svn/git).
+   * "url" (string) : Url to the repository (svn/git), URL to fetch tar file (tar), or path to the directory (local)
+   
+#### ISO Example
+```
+"iso" : {
+  "file-name": "TrueOS-x64-%%TRUEOS_VERSION%%-%%GITHASH%%-%%DATE%%",
+  "install-script" : "/usr/local/bin/my-installer",
+  "auto-install-script" : "",
+  "post-install-commands": [
+      {
+        "chroot": true,
+        "command": "touch /root/inside-chroot"
+      },
+      {
+        "chroot": false,
+        "command": "touch /root/outside-chroot"
+      },
+      {
+        "chroot": true,
+        "command": "rm /root/outside-chroot"
+      },
+      {
+        "chroot": false,
+        "command": "rm /root/inside-chroot"
+      }
+  ],
+  "prune": {
+    "ENV_VARIABLE": [
+      "/usr/share/examples",
+      "/usr/include"
+    ],
+    "default": [
+      "/usr/local/share/examples",
+      "/usr/local/include"
+    ]
+  },
+  "ignore-base-packages": [
+    "-clang-",
+    "-sendmail-"
+  ],
+  "iso-packages": {
+    "default": [
+      "sysutils/ipmitool",
+      "sysutils/dmidecode",
+      "sysutils/tmux"
+    ],
+    "ENV_VARIABLE": [
+      "archivers/cabextract"
+    ]
+  },
+  "dist-packages": {
+    "default": [
+      "sysutils/ipmitool",
+      "sysutils/dmidecode",
+      "sysutils/tmux"
+    ],
+    "ENV_VARIABLE": [
+      "archivers/cabextract"
+    ]
+  },
+  "auto-install-packages": {
+    "default": [
+      "sysutils/ipmitool",
+      "sysutils/dmidecode",
+      "sysutils/tmux"
+    ],
+    "ENV_VARIABLE": [
+      "archivers/cabextract"
+    ]
+  },
+  "overlay": {
+    "type": "git",
+    "branch": "master",
+    "url": "https://github.com/trueos/iso-overlay"
+  }
+}
+```
+
+### ports
+The "ports" target allows for configuring the build targets and options for the ports system. That can include changing the default version for particular packages, selecting a subset of packages to build, and more.
+
+#### Ports Options
+* "type" (string) : One of the following: [git, svn, tar, local, null]. Where to look for the ports tree.
+* "branch" (string) : Branch of the repository to use (svn/git only)
+* "url" (string) : URL to the repository (svn/git), where to fetch the tar file (tar), or path to directory (local)
+* "local_source" (string) : Path to a local directory where the ports tree should be placed (used for reproducible builds). This directory name will be visible in the output of `uname` on installed systems.
+* "build-all" (boolian) : Build the entire ports collection (true/false)
+* "build" (JSON object) : Lists of packages (by port origin) to build. If "build-all" is true, then this list will be treated as "essential" packages and if any of them fail to build properly then the entire build will be flagged as a failure.
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name is set
+* "make.conf" (JSON object) : Lists of build flags for use when building the ports.
+   * "default" (JSON array of strings) : Default list (required)
+   * "ENV_VARIABLE" (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name is set
+* "strip-plist" (JSON array of strings) : List of files or directories to remove from any packages that try to use them.
+
+#### Ports Example
+```
+"ports" : {
+  "type" : "git",
+  "branch" : "trueos-master",
+  "url" : "https://github.com/trueos/trueos-ports",
+  "local_source" : "/usr/ports",
+  "build-all" : false,
+  "build" : {
+    "default" : [
+      "sysutils/tmux",
+      "shells/zsh",
+      "shells/fish"
+    ],
+    "ENV_VARIABLE" : [
+      "shells/bash"
+    ]
+  },
+  "make.conf" : {
+    "default" : [
+      "shells_zsh_SET=STATIC",
+      "shells_zsh_UNSET=EXAMPLES"
+    ],
+    "ENV_VARIABLE" : [
+      "shells_bash_SET=STATIC"
+    ]
+  },
+  "strip-plist":[
+	  "/usr/local/share/doc/tmux",
+	  "/usr/local/share/examples/tmux"
+  ]
+}
+```
+
+### poudriere
+The "poudriere" object allows the configuration of the poudriere build system for individual build manifests, allowing many different builds to be performed on the same system without conflicting with each other.
+
+#### Poudriere Options
+* "jailname" (string) : Use this name internally for the jail which is used for the builds.
+   * If not provided, the "trueos-mk-base" name will be used.
+* "portsname" (string) : Use this name internally for the ports tree used by the build.
+   * If not provided, the "trueos-mk-ports" name will be used.
+
+### base-packages
+The "base-packages" target allows the configuration of the OS packages itself. This can involve the naming scheme, build flags, extra dependencies, and more.
+
+
+### poudriere-conf
+This field contains a list of options to use to configure the poudriere instance that will build the packages. The configuration of poudriere is automatically performed to ensure an optimal result for most build systems, but it is possible to further customize these settings as needed.
+
+#### Poudriere-conf Options
+* "poudriere-conf" (JSON array of strings) : List of configuration options for poudriere
+* */etc/poudriere.conf.release* - If this file exists on the system, it will be appended as a whole to the auto-generated config.
+
+Common options to configure:
+
+* "NOHANG_TIME=[number]" : Number of seconds a port build can be "silent" before poudriere stops the build.
+* "PREPARE_PARALLEL_JOBS=[number]" : Number of CPUs to use when setting up poudriere (typical setting: Number of CPU's - 1)
+* "PARALLEL_JOBS=[number]" : Number of ports to build at any given time.
+* "ALLOW_MAKE_JOBS=[yes/no]" : Allow ports to build with more than one CPU. 
+   * *WARNING:* Make sure to set the "MAKE_JOBS_NUMBER_LIMIT=[number]" in the builds -> make.conf settings to restrict ports to a particular number of CPUs as well.
+* USE_TMPFS=[all, yes, wrkdir, data, localbase, no]" : Set how much of the port builds should be performed in memory.
+
+#### Poudriere-conf Example
+```
+"poudriere-conf": [
+	"NOHANG_TIME=14400",
+	"PREPARE_PARALLEL_JOBS=15",
+	"PARALLEL_JOBS=3",
+	"USE_TMPFS='yes'",
+	"ALLOW_MAKE_JOBS=yes"
+]
+```
+
+An example of the automatically-generated config file is included below for reference (if nothing is supplied via the JSON manifest):
+```
+# Base Poudriere setup for build environment
+ZPOOL=${ZPOOL}
+FREEBSD_HOST=file://${DIST_DIR}
+GIT_URL=${GH_PORTS}
+BASEFS=${POUDRIERE_BASEFS}
+# Change a couple poudriere defaults to integrate with an automated build
+USE_TMPFS=data
+ATOMIC_PACKAGE_REPOSITORY=no
+PKG_REPO_FROM_HOST=yes
+# Optimize the building of known "large" ports (if selected for build)
+ALLOW_MAKE_JOBS_PACKAGES="chomium* iridium* gcc* webkit* llvm* clang* firefox* ruby* cmake* rust*"
+PRIORITY_BOOST="pypy* openoffice* iridium* chromium*"
+```
+
+### pkg-repo
+As part of the build process, the packages can also be automatically assembled into a full package repository which may be used for providing access to the newly-build packages on other systems.
+
+#### pkg-repo Options
+* "pkg-repo-name" (string) : Short-name for the package repository (default: "TrueOS")
+* "pkg-train-name" (string) : Name for the package repository train used by sysutils/sysup (default: "TrueOS")
+* "pkg-repo" (JSON Object) : Settings for the unified base+ports package repo
+   * "url" (string) : Public URL where the repository can be found. (Distro creators will need to setup access for this URL and copy the pkg repo files as needed to make them available at the given location).
+   * "pubKey" (JSON Array of strings) : SSL public key to use when verifying integrity of downloaded packages (one line of test per item in the array). This is basically just the plain-text of the SSL public key file converted into an array of strings. 
+      * **WARNING** Make sure that this public key is the complement to the private key that you are using to sign the packages!!
+   
+#### pkg-repo Example
+
+```
+"pkg-repo-name" : "TrueOS",
+"pkg-train-name" : "snapshot",
+"pkg-repo" : {
+  "url" : "http://pkg.trueos.org/pkg/release/${ABI}/latest",
+  "pubKey : [
+    "-----BEGIN PUBLIC KEY-----",
+    "sdigosbhdgiub+asdgilpubLIUYASVBfiGULiughlBHJljib"
+    "-----END PUBLIC KEY-----"
+  ]
+}
+```
+
+*This documentation was provided by Ken Moore from the [Project Trident](https://project-trident.org) distribution of TrueOS*

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -93,7 +93,7 @@ The "iso" target within the manifest controls all the options specific to creati
 * **iso-packages** (JSON object) : Lists of packages (by port origin) to install into the ISO (when booting the ISO, these packages will be available to use)
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
-* **auto-install-packages** (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer or when creating a VM image.
+* **auto-install-packages** (JSON object) : Lists of packages (by port origin) to automatically install when using the default TrueOS installer.
    * **NOTE:** These packages will automatically get added to the "dist-packages" available on the ISO as well.
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
@@ -191,6 +191,10 @@ The "vm" target is used to provide custom settings when assembling a VM image wi
 * **disk-config** (string) : Name of the disk configuration script to use from the [vm-diskcfg directory](https://github.com/trueos/build/master/vm-diskconfig).
    * Example: a value of "zfs-noswap" will use the "vm-diskcfg/zfs-noswap.sh" disk configuration script to setup the VM.
 * **boot** (string) : Either "zfs" or "ufs". Use this filesystem for the VM image.
+* **auto-install-packages** (JSON object) : Lists of packages (by port origin) to automatically install into the VM image.
+   * **NOTE:** If this field is missing, it will use the "iso" version of the "auto-install-packages" field as a fallback list.
+   * **default** (JSON array of strings) : Default list (required)
+   * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
 
 #### VM Example
 ```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,8 +43,8 @@ exit_err()
 if [ -z "$TRUEOS_MANIFEST" ] ; then
 	if [ -e ".config/manifest" ] ; then
 		export TRUEOS_MANIFEST="$(pwd)/manifests/$(cat .config/manifest)"
-	elif [ -e "$(pwd)/manifests/trueos-snapshot.json" ] ; then
-		export TRUEOS_MANIFEST="$(pwd)/manifests/trueos-snapshot.json"
+	elif [ -e "$(pwd)/manifests/trueos-snapshot-builder.json" ] ; then
+		export TRUEOS_MANIFEST="$(pwd)/manifests/trueos-snapshot-builder.json"
 	fi
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -238,7 +238,7 @@ setup_poudriere_ports()
 	fi
 
 	# Do we have any locally checked out sources to copy into poudirere jail?
-	LOCAL_SOURCE_DIR=source
+	LOCAL_SOURCE_DIR=${LOCAL_SOURCE_DIR:-source}
 	if [ -n "$LOCAL_SOURCE_DIR" -a -d "${LOCAL_SOURCE_DIR}" ] ; then
 		rm -rf ${POUDRIERE_PORTDIR}/local_source 2>/dev/null
 		cp -a ${LOCAL_SOURCE_DIR} ${POUDRIERE_PORTDIR}/local_source

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1113,13 +1113,20 @@ create_vm_dir()
 	done
 
 	# Install the packages from JSON manifest
+	# - get whether to use the "iso" or "vm" parent object
+	local pobj="vm"
+	jq -e '."vm"."auto-install-packages"' ${TRUEOS_MANIFEST} 2>/dev/null
+	if [ $? -ne 0 ] ; then
+		pobj="iso"
+	fi
+	# - Now loop through the list
 	for ptype in auto-install-packages
 	do
-		for c in $(jq -r '."iso"."'${ptype}'" | keys[]' ${TRUEOS_MANIFEST} 2>/dev/null | tr -s '\n' ' ')
+		for c in $(jq -r '."'${pobj}'"."'${ptype}'" | keys[]' ${TRUEOS_MANIFEST} 2>/dev/null | tr -s '\n' ' ')
 		do
 			eval "CHECK=\$$c"
 			if [ -z "$CHECK" -a "$c" != "default" ] ; then continue; fi
-			for i in $(jq -r '."iso"."'${ptype}'"."'$c'" | join(" ")' ${TRUEOS_MANIFEST})
+			for i in $(jq -r '."'${pobj}'"."'${ptype}'"."'$c'" | join(" ")' ${TRUEOS_MANIFEST})
 			do
 				if [ -z "${i}" ] ; then continue; fi
 				echo "Installing: $i"


### PR DESCRIPTION
Large documentation update of all the build options for the main "make" command, as well as an updated build manifest readme with all the supported fields/options for version 1.1 of the manifest system.

Also fix an oversight in the local source dir path: Allow it to be defined by an environment variable and only use the "source" relative path as the default value if the env variable is not defined (no change to default behavior).