### PR TITLE
[change] Pkg Repo Management files (output manifests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,30 @@ This will launch an interactive prompt to select a build manifest from the examp
 The selected Manifest name will get saved to the local ".config/manifest" file and used whenever the **TRUEOS_MANIFEST** environment variable is not set. This command may be run whenever a different default manifest is desired.
 
 ### make ports
-|Output Files|Output Ports Logs| Output Source Logs |
-|:---:|:---:|:---:|
-|release/packages |release/port-logs | release/src-logs| 
+|Output Files|Output Ports Logs| Output Source Logs | Output Manifests |
+|:---:|:---:|:---:|:---:|
+|release/packages |release/port-logs | release/src-logs| release/pkg-manifests |
 
 Assemble packages for the OS and any ports listed in the build manifest. These packages will be automatically treated as  a full repository for use as needed.
 
-Optional inputs (environment variables):
+#### Optional inputs (environment variables):
 * **POUDRIERE_BASEFS** : This is the path to the poudriere working directory ("/usr/local/poudriere" by default)
 * **SIGNING_KEY** : This is the private key which should be used to sign the packages once they are built.
 * **LOCAL_SOURCE_DIR** : Location of any additional source files which need to be copied into the OS source tree (source tree overlay).
    * Default value: "source"
+
+#### Output directory details:
+* release/packages (symlink) : Main outputs. Directory structure containing package repository
+* release/port-logs (symlink) : Poudriere build logs for each package are contained here.
+* release/src-logs (symlink) : Special build logs for the buildworld/buildkernel base packages.
+* release/pkg-manifests (optional) : Additional repository management files
+   * The "ports" -> "generate-manifests" field must be set to `true` to generate these outputs
+   * Manifest files contain:
+      * CHANGES : Management file from the version of the ports tree that was used.
+      * MOVED : Management file from the version of the ports tree that was used.
+      * UPDATING : Management file from the version of the ports tree that was used.
+      * pkg.list : Plaintext file containing a list of all packages contained in the repo (one package per line)
+         * Line syntax: "[port origin] : [package name] : [package version]")
 
 ### make iso
 |Output Files|Output Logs|

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -216,6 +216,7 @@ The "ports" target allows for configuring the build targets and options for the 
 * **url** (string) : URL to the repository (svn/git), where to fetch the tar file (tar), or path to directory (local)
 * **local_source** (string) : Path to a local directory where the ports tree should be placed (used for reproducible builds). This directory name will be visible in the output of `uname` on installed systems.
 * **build-all** (boolean) : Build the entire ports collection (true/false)
+* **generate-manifests** (boolean) : Assemble the "pkg-manifests" directory of repo-management files. (true/false)
 * **build** (JSON object) : Lists of packages (by port origin) to build. If "build-all" is true, then this list will be treated as "essential" packages and if any of them fail to build properly then the entire build will be flagged as a failure.
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name is set
@@ -232,6 +233,7 @@ The "ports" target allows for configuring the build targets and options for the 
   "url" : "https://github.com/trueos/trueos-ports",
   "local_source" : "/usr/ports",
   "build-all" : false,
+  "generate-manifests" : false,
   "build" : {
     "default" : [
       "sysutils/tmux",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -499,25 +499,9 @@ build_poudriere()
 		cp "$(find ${POUDRIERE_PORTDIR} -maxdepth 3 -name UPDATING)" ${mandir}/.
 		cp "$(find ${POUDRIERE_PORTDIR} -maxdepth 3 -name CHANGES)" ${mandir}/.
 		# Assemble a quick list of all the ports/packages that are available in the repo
-		# NOTE: This entire section could be replaced by a single pkg command if we could figure out
-		#  how to manually tell pkg to use this repo for a quick query
-		#  pkg [setup flags] query -a "%o : %n : %v" > "${mandir}/pkg.list
+		mk_repo_config
+		pkg-static -R tmp/repo-config query -a "%o : %n : %v" > "${mandir}/pkg.list"
 
-		# Find the actual dir which contains all the package files
-		local _pkgdir=$(find release/packages -maxdepth 4 -name "All")
-		for _path in `find "${_pkgdir}" -depth 1 -name "*.txz" | sort`
-		do
-			#Cleanup the individual line (directory, suffix)
-			_line=$(basename ${_path} | sed "s|.txz||g")
-			#Make sure it is a valid package name - otherwise skip it
-			case "${_line}" in
-				fbsd-distrib) continue ;;
-				*-*) ;;
-				*) continue ;;
-			esac
-			#Read off the name/version of the package file and put it into the manifest
-			pkg query -F "${_path}" "%o : %n : %v" >> "${mandir}/pkg.list"
-		done
 	fi
 	return 0
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -495,9 +495,9 @@ build_poudriere()
 			mkdir -p "${mandir}"
 		fi
 		# Copy over the relevant files from the ports tree
-		cp "${POUDRIERE_PORTDIR}/MOVED" ${mandir}/.
-		cp "${POUDRIERE_PORTDIR}/UPDATING" ${mandir}/.
-		cp "${POUDRIERE_PORTDIR}/CHANGES" ${mandir}/.
+		cp "$(find ${POUDRIERE_PORTDIR} -maxdepth 3 -name MOVED)" ${mandir}/.
+		cp "$(find ${POUDRIERE_PORTDIR} -maxdepth 3 -name UPDATING)" ${mandir}/.
+		cp "$(find ${POUDRIERE_PORTDIR} -maxdepth 3 -name CHANGES)" ${mandir}/.
 		# Assemble a quick list of all the ports/packages that are available in the repo
 		# NOTE: This entire section could be replaced by a single pkg command if we could figure out
 		#  how to manually tell pkg to use this repo for a quick query


### PR DESCRIPTION
Add a new optional field to the build manifest:
"ports" . "generate-manifests" (true/false : default false)

When enabled, this will assemble a release/pkg-manifests directory after a successful ports build which contains the following:

* CHANGES file from the ports tree
* MOVED file from the ports tree
* UPDATING file from the ports tree
* Generates a "pkg.list" file containg a list of all the packages in the repo (port origin, package name, package version)

NOTE:
The pkg.list generation routine is a bit slow right now, but it works. I put a note in that section for a one-liner "pkg" command which will do the same thing about 1000x faster, but I am still unable to determine how to point the pkg utility at that repo for doing the query (which is why it is not enabled right now).