### PR TITLE
[change] ISO/IMG File signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Use the package repository to assemble an ISO (hybrid DVD/USB image).
 **Note:** For any "*.iso" file that is created, this process will also generate *.sha256 and *.md5 checksum files as well.
 
 Optional inputs (environment variables):
-* *TO-DO*
+* **SIGNING_KEY** : This is the private key which should be used to sign the ISO file once it is built.
+   * This will also create a "pubkey.pem" file in the output dir which contains the public key for the signature verification
 
 ### make vm
 |Output Files|Output Logs|
@@ -87,6 +88,8 @@ Use the package repository to assemble a pre-installed VM image.
 **Note:** For any "*.img" file that is created, this process will also generate *.sha256 and *.md5 checksum files as well.
 
 Optional inputs (environment variables):
+* **SIGNING_KEY** : This is the private key which should be used to sign the IMG file once it is built.
+   * This will also create a "pubkey.pem" file in the output dir which contains the public key for the signature verification
 * **VMPOOLNAME** : Create/use a temporary ZFS pool with this name for the VM build environment.
    * Default Value: "vm-gen-pool"
  

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -648,6 +648,37 @@ EOF
 
 }
 
+sign_file(){
+  # Sign a file with openssl
+  local file="$1"
+
+  if [ -z "${SIGNING_KEY}" ] ; then
+    echo "No signing key provided - skipping signing of file: ${file}"
+    return 0
+  fi
+  echo "Signing file: ${file}"
+  openssl dgst -sha512 -sign "${SIGNING_KEY}" -out "${file}.sig.sha512" "${file}"
+  if [ $? -ne 0 ] ; then
+    echo "ERROR signing file!"
+    return 1
+  fi
+  echo " - Generating pubkey for signature verification"
+  # Need an actual file for the pubkey
+  local keyfile
+  if [ -e "${SIGNING_KEY}" ] ; then
+    keyfile="${SIGNING_KEY}"
+  else
+    keyfile="_internal_priv.key"
+    echo "${SIGNING_KEY}" > "${keyfile}"
+  fi
+  openssl rsa -in "${keyfile}" -pubout -out $(dirname "${file}")/pubkey.pem
+  #Make sure we delete any temporary private key file
+  if [ "${keyfile}" = "_internal_priv.key" ] ; then
+    rm "${keyfile}"
+  fi
+  return 0
+}
+
 clean_iso_dir()
 {
 	if [ ! -d "${ISODIR}" ] ; then
@@ -934,6 +965,7 @@ mk_iso_file()
 	fi
 	sha256 -q release/iso/${NAME} > release/iso/${NAME}.sha256
 	md5 -q release/iso/${NAME} > release/iso/${NAME}.md5
+	sign_file release/iso/${NAME}
 }
 
 check_version()
@@ -1269,6 +1301,7 @@ do_vm_create() {
 	echo "Creating checksums"
 	sha256 -q release/vm/${NAME} > release/vm/${NAME}.sha256
 	md5 -q release/vm/${NAME} > release/vm/${NAME}.md5
+	sign_file release/vm/${NAME}
 }
 
 do_iso_create() {


### PR DESCRIPTION
Add a generic "sign_file()" function which will use the same "SIGNING_KEY" environment variable that is used for package signing.

Hook this into the ISO and vm IMG creation routines so that output *.iso and *.img files can now be optionally signed if that environment variable is provided.

Adds files to output dir:
* FILENAME.sig.sha512 : signature file - sha512 format
* pubkey.pem : public key that can be used to verify the signature.