### PR TITLE
[change] Output File Manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ Assemble packages for the OS and any ports listed in the build manifest. These p
 |Output Files|Output Logs|
 |:---:|:---:|
 |release/iso |release/iso-logs |
+|release/update |release/iso-logs/01_offline_update.log |
 
-Use the package repository to assemble an ISO (hybrid DVD/USB image).
+Use the package repository to assemble an ISO (hybrid DVD/USB image). If the "iso" -> "offline_update" field is set to "true" in the build manifest, the release/update directory will also get created for the offline update image and associated checksums.
 
 **Note:** For any "*.iso" file that is created, this process will also generate *.sha256 and *.md5 checksum files as well.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -200,6 +200,57 @@ create_release_links()
 	ln -fs ${POUDRIERE_PKGLOGS} release/port-logs
 }
 
+assemble_file_manifest(){
+	# Assemble a manifest.json file containing references to all the files in this directory.
+	# INPUTS
+	# $1 : Directory to scan and place the manifest
+	local dir="$1"
+	local mfile="$(dirname ${dir})/manifest.json"
+	local manifest
+	local var
+	for file in `ls "${dir}"` ; do
+		name="$(basename ${file})"
+		var=""
+		case "${name}"
+			*.iso)
+				var="\"iso_file\" : \"${name}\", \"iso_size\" : \"$(ls -lh ${dir}/${name} | cut -w -f 5)\""
+				;;
+			*.img)
+				var="\"img_file\" : \"${name}\", \"img_size\" : \"$(ls -lh ${dir}/${name} | cut -w -f 5)\""
+				;;
+			*.sig.*)
+				var="\"signature_file\" : \"${name}\""
+				;;
+			*.md5)
+				var="\"md5_file\" : \"${name}\", \"md5\" : \"$(cat ${dir}/${name})\""
+				;;
+			*.sha256)
+				var="\"sha256_file\" : \"${name}\", \"sha256\" : \"$(cat ${dir}/${name})\""
+				;;
+		esac
+		if [ -n "${var}" ] ; then
+			if [ -n "${manifest}" ] ; then
+				#Next item in the object
+				manifest="${manifest}, ${var}"
+			else
+				#First item
+				manifest="${var}"
+			fi
+		fi
+	done
+	if [ -n "${manifest}" ] ; then
+		# Also inject the date/time of the current build here
+		local _date=`date -ju "+%Y_%m_%d %H:%M %Z"`
+		local _date_secs=`date -j +%s`
+		manifest="${manifest}, \"build_date\" : \"${_date}\", \"build_date_time_t\" : \"${_date_secs}\""
+		echo "{ ${manifest} }" > "${mfile}"
+		return 0
+	else
+		# No files? Return an error
+		return 1
+	fi
+}
+
 is_ports_dirty()
 {
 	# Does ports tree already exist?
@@ -787,6 +838,7 @@ create_offline_update()
 	fi
 	sha256 -q release/update/${NAME} > release/update/${NAME}.sha256
 	md5 -q release/update/${NAME} > release/update/${NAME}.md5
+	assemble_file_manifest "release/update"
 }
 
 setup_iso_post() {
@@ -934,6 +986,8 @@ mk_iso_file()
 	fi
 	sha256 -q release/iso/${NAME} > release/iso/${NAME}.sha256
 	md5 -q release/iso/${NAME} > release/iso/${NAME}.md5
+
+	assemble_file_manifest "release/iso"
 }
 
 check_version()
@@ -1269,6 +1323,8 @@ do_vm_create() {
 	echo "Creating checksums"
 	sha256 -q release/vm/${NAME} > release/vm/${NAME}.sha256
 	md5 -q release/vm/${NAME} > release/vm/${NAME}.md5
+
+	assemble_file_manifest "release/vm"
 }
 
 do_iso_create() {


### PR DESCRIPTION
For output directories of image files or iso's, automatically generate a "manifest.json" file containing links/references to all the various files and add timestamps within the manifest.

Also update a bit of documentation about the output directory for offline update images.