### PR TITLE
Remove old port tree in case of branch change

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -215,6 +215,8 @@ is_ports_dirty()
 
 	# Have we changed branches?
 	if [ "$CURBRANCH" != "${PORTS_BRANCH}" ] ; then
+		echo "Branch change detected, checking out ports fresh"
+		echo -e "y\n" | poudriere ports -d -p ${POUDRIERE_PORTS}
 		return 1
 	fi
 


### PR DESCRIPTION
This commit makes sure we remove old ports tree if a branch change is detected as else we failed to checkout the new ports tree because the old one still existed.
Ticket: #80364