### PR TITLE
[change] Make all the file-manifests (manifest.json) optional.

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -81,6 +81,8 @@ The "iso" target within the manifest controls all the options specific to creati
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
 * **offline-update** (boolean) : If set to true will generate a system-update.img file containing ISOs dist files
+* **generate-manifest** (boolean) : If set to true, will generate a "manifest.json" file containing references or contents of all the files in the ISO output directory.
+* **generate-update-manifest** (boolean) : If set to true, will generate a "manifest.json" file containing references or contents of all the files in the offline-update output directory.
 * **optional-dist-packages** (JSON object) : Lists of packages (by port origin) to have available in .txz form on the ISO. These ones are considered "optional" and may or may not be included depending on whether the package built successfully.
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
@@ -195,6 +197,7 @@ The "vm" target is used to provide custom settings when assembling a VM image wi
    * **NOTE:** If this field is missing, it will use the "iso" version of the "auto-install-packages" field as a fallback list.
    * **default** (JSON array of strings) : Default list (required)
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
+* **generate-manifest** (boolean) : If set to true, will generate a "manifest.json" file containing references or contents of all the files in the VM output directory.
 
 #### VM Example
 ```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -928,7 +928,10 @@ create_offline_update()
 	fi
 	sha256 -q release/update/${NAME} > release/update/${NAME}.sha256
 	md5 -q release/update/${NAME} > release/update/${NAME}.md5
-	assemble_file_manifest "release/update"
+
+	if [ $(jq -r '."iso"."generate-update-manifest"' ${TRUEOS_MANIFEST}) = "true" ] ; then
+		assemble_file_manifest "release/update"
+	fi
 }
 
 setup_iso_post() {
@@ -1078,7 +1081,9 @@ mk_iso_file()
 	sha256 -q release/iso/${NAME} > release/iso/${NAME}.sha256
 	md5 -q release/iso/${NAME} > release/iso/${NAME}.md5
 	sign_file release/iso/${NAME}
-	assemble_file_manifest "release/iso"
+	if [ $(jq -r '."iso"."generate-manifest"' ${TRUEOS_MANIFEST}) = "true" ] ; then
+		assemble_file_manifest "release/iso"
+	fi
 }
 
 check_version()
@@ -1416,7 +1421,9 @@ do_vm_create() {
 	sha256 -q release/vm/${NAME} > release/vm/${NAME}.sha256
 	md5 -q release/vm/${NAME} > release/vm/${NAME}.md5
 	sign_file release/vm/${NAME}
-	assemble_file_manifest "release/vm"
+	if [ $(jq -r '."vm"."generate-manifest"' ${TRUEOS_MANIFEST}) = "true" ] ; then
+		assemble_file_manifest "release/vm"
+	fi
 }
 
 do_iso_create() {


### PR DESCRIPTION
Now this is triggered by a "generate-manifest" option in each of the individual build phase sections (iso, vm).

Build manifest documentation also updated for each of the new build options.