### PR TITLE
[change] Add a new manifest option: "base-packages" . "trueos-branch".

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -30,6 +30,9 @@ The "base-packages" target allows the configuration of the OS packages itself. T
    * **ENV_VARIABLE** (JSON array of strings) : Additional list to be added to the "default" list **if** an environment variable with the same name exists.
    * ***WARNING:*** The only kernel flag that should be optionally set here is the "KERNCONF" setting for selecting a custom kernel configuration. All other world/kernel options are exposed via port options on the "buildworld" and "buildkernel" ports and should be modified in the "ports -> make.conf" section of the manifest.
 * **strip-plist** (JSON array of strings) :  List of directories or files that need to be removed from the base-packages.
+* **trueos-branch** (string) : Supply a branch name from the trueos/trueos github repository to use for the OS branch.
+   * This will ensure that all the base packages use the version of the OS that comes from this branch.
+   * If unset, the build will use whichever version of the base packages are currently set in the ports tree.
 
 #### Base Packages Example
 ```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -370,6 +370,15 @@ setup_poudriere_ports()
 		jq -r '."ports"."make.conf"."'$c'" | join("\n")' ${TRUEOS_MANIFEST} >>${POUDRIERED_DIR}/${POUDRIERE_BASE}-make.conf
 	done
 
+	# See if a particular version of the base sources is specified
+	#  and ensure the base ports are all pointing to the right branch of the OS repo
+	if [ -e "${POUDRIERE_PORTDIR}/update-branch-os.sh" ] ; then
+		local os_branch=$(jq -r '."base-packages"."trueos-branch"' ${TRUEOS_MANIFEST})
+		if [ -n "${os_branch}" ] && [ "${os_branch}" != "null" ] ; then
+			echo "Adjusting TrueOS version branch: ${os_branch}"
+			(cd "${POUDRIERE_PORTDIR}" && ./update-branch-os.sh "os" "${os_branch}")
+		fi
+	fi
 }
 
 create_poudriere_ports()


### PR DESCRIPTION
If set, this will run the update-branch-os.sh script from the ports tree to ensure all the base packages are set to the same version of the OS repo.

This provides a one-line mechanism for a distributor to pick which OS version they want to build against.