### PR TITLE
PDIR fix so we update existing port tree

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -326,6 +326,7 @@ is_ports_dirty()
 		return 1
 	fi
 
+	PDIR="$(poudriere ports -l 2>/dev/null | grep -w ${POUDRIERE_PORTS} | cut -w -f5)"
 	CURBRANCH=$(cd ${PDIR} 2>/dev/null && git branch | awk '{print $2}')
 	if [ -z "$CURBRANCH" ] ; then
 		echo "Unable to detect branch, checking out ports fresh"


### PR DESCRIPTION
As far as I can tell we were continually rechecking out a new ports tree instead of reusing/updating current one

