### PR TITLE
Build: VM: fix package installation and zfsboot

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1413,25 +1413,11 @@ create_vm_dir()
 
 	mk_repo_config
 
-	BASE_PACKAGES="os/userland os/kernel ports-mgmt/pkg textproc/jq"
-
 	mkdir -p ${VMDIR}/tmp
 	mkdir -p ${VMDIR}/var/db/pkg
 	cp -r tmp/repo-config ${VMDIR}/tmp/repo-config
 
 	export PKG_DBDIR="tmp/pkgdb"
-
-	# Install the base packages into vm dir
-	for pkg in ${BASE_PACKAGES}
-	do
-		pkg-static -r ${VMDIR} -o ABI_FILE=${POUDRIERE_JAILDIR}/bin/sh \
-			-R tmp/repo-config \
-			install -y ${pkg}
-		if [ $? -ne 0 ] ; then
-			exit_err "Failed installing base packages to VM directory..."
-		fi
-
-	done
 
 	# Install the packages from JSON manifest
 	# - get whether to use the "iso" or "vm" parent object

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1463,6 +1463,8 @@ run_vm_post_install() {
 			echo "Stamping ZFS boot-loader"
 			echo "gpart bootcode -b ${VMDIR}/boot/pmbr -p ${VMDIR}/boot/gptzfsboot -i 1 ${MDDEV}"
 			gpart bootcode -b ${VMDIR}/boot/pmbr -p ${VMDIR}/boot/gptzfsboot -i 1 ${MDDEV} || exit_err "failed stamping boot!"
+			touch ${VMDIR}/boot/loader.conf
+			sysrc -f ${VMDIR}/boot/loader.conf zfs_load=YES
 			;;
 	esac
 


### PR DESCRIPTION
I've had some issues with building and booting VMs with flavors and zfs.

The first commit changes vm package installation to not use BASE_PACKAGES and just install all auto-install-packages. It previously tried to install random base and kernel flavors because it does not specify specific flavors. The ISO install might have the same issue but the fix would be different (maybe remove BASE_PACKAGES and make it use iso-packages).

The second commit makes sure zfs_load is set in loader.conf if necessary.