### PR TITLE
Fix /dev/null errors with make iso

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1088,6 +1088,13 @@ EOF
 	if [ $? -ne 0 ] ; then
 		exit_err "Failed mounting nullfs to ${ISODIR}/install-pkg"
 	fi
+	
+	mount -t devfs devfs ${ISODIR}/dev
+	$PWD
+	ls -la 
+	if [ $? -ne 0 ] ; then
+		exit_err "Failed mounting devfs to ${ISODIR}/dev"
+	fi
 
 	# Prep the new ISO environment
 	chroot ${ISODIR} pwd_mkdb /etc/master.passwd
@@ -1138,6 +1145,7 @@ EOF
 	done
 
 	# Cleanup the ISO install packages
+	umount -f ${ISODIR}/dev
 	umount -f ${ISODIR}/install-pkg
 	rmdir ${ISODIR}/install-pkg
 	rm ${ISODIR}/etc/pkg/*


### PR DESCRIPTION
When installing packages in chroot we need to mount devfs now. Original thread https://lists.freebsd.org/pipermail/freebsd-current/2019-June/073565.html

This is patch is tested:
w/o patch: http://jenkins.fbsd.io/job/debug/5/artifact/release/iso-logs/02_iso_post.log
with patch: http://jenkins.fbsd.io/job/debug/7/artifact/release/iso-logs/02_iso_post.log