### PR TITLE
Cleanup more poudriere datasets

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -805,7 +805,7 @@ super_clean_poudriere()
 	#Now look for any leftover ZFS datasets for previous build jails
 	# These are typically left behind if something like a system reboot happens during a build
 	#  but poudriere does not know to scan/clean them before starting a new build
-	for jail_ds in `zfs list | grep -e "/poudriere/jails/${POUDRIERE_BASE}" -e '(-ref/)[0-9]+$' | cut -w -f 1`
+	for jail_ds in `zfs list | grep -e "/poudriere/jails/${POUDRIERE_BASE}" | grep -E '(-ref/)[0-9]+' | cut -w -f 1`
 	do
 		echo "Removing stale package build dataset: ${jail_ds}"
 		zfs destroy "${jail_ds}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -808,7 +808,7 @@ super_clean_poudriere()
 	for jail_ds in `zfs list | grep -e "/poudriere/jails/${POUDRIERE_BASE}" | grep -E '(-ref/)[0-9]+' | cut -w -f 1`
 	do
 		echo "Removing stale package build dataset: ${jail_ds}"
-		zfs destroy "${jail_ds}"
+		zfs destroy -r "${jail_ds}"
 	done
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -802,6 +802,14 @@ super_clean_poudriere()
 			fi
 		fi
 	done
+	#Now look for any leftover ZFS datasets for previous build jails
+	# These are typically left behind if something like a system reboot happens during a build
+	#  but poudriere does not know to scan/clean them before starting a new build
+	for jail_ds in `zfs list | grep -e "/poudriere/${POUDRIERE_BASE}" -e '(-ref/)[0-9]+$' | cut -w -f 1`
+	do
+		echo "Removing stale package build dataset: ${jail_ds}"
+		zfs destroy "${jail_ds}"
+	done
 }
 
 # If we did a bulk -a of poudriere, ensure we have everything mentioned in the MANIFEST

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -805,7 +805,7 @@ super_clean_poudriere()
 	#Now look for any leftover ZFS datasets for previous build jails
 	# These are typically left behind if something like a system reboot happens during a build
 	#  but poudriere does not know to scan/clean them before starting a new build
-	for jail_ds in `zfs list | grep -e "/poudriere/${POUDRIERE_BASE}" -e '(-ref/)[0-9]+$' | cut -w -f 1`
+	for jail_ds in `zfs list | grep -e "/poudriere/jails/${POUDRIERE_BASE}" -e '(-ref/)[0-9]+$' | cut -w -f 1`
 	do
 		echo "Removing stale package build dataset: ${jail_ds}"
 		zfs destroy "${jail_ds}"


### PR DESCRIPTION
Cleanup stale poudriere build jails before starting a build.
This typically happens if the build server crashes and reboots in the middle of a build, or if the build somehow gets stopped without poudriere doing it's own normal cleanup routines.