### PR TITLE
Fix RPI3 build boot

### DIFF
--- a/img-cfg/rpi3.conf
+++ b/img-cfg/rpi3.conf
@@ -4,7 +4,7 @@
 #
 
 DTB_DIR="/usr/local/share/rpi-firmware"
-DTB="bcm2710-rpi-3-b.dtb"
+DTB="bcm2710-rpi-3-b.dtb bcm2710-rpi-3-b-plus.dtb"
 MD_ARGS="-x 63 -y 255"
 OL_DIR="${DTB_DIR}/overlays"
 OVERLAYS="mmc.dtbo pwm.dtbo pi3-disable-bt.dtbo"
@@ -18,6 +18,8 @@ arm_boot_setup() {
 	FATMOUNT="img-mnt-fat"
 	mkdir -p "${FATMOUNT}"
 	mount_msdosfs /dev/${MDDEV}s1 ${FATMOUNT}
+	mkdir -p ${FATMOUNT}/EFI/BOOT
+	cp tmp/loader.efi ${FATMOUNT}/EFI/BOOT/bootaa64.efi
 	if [ $? -ne 0 ] ; then
 		echo "Failed mounting ${MDDEV}s1 -> ${FATMOUNT}"
 	fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1581,6 +1581,9 @@ create_image_dir()
 		fi
 
 	done
+	# Copy efi loader to tmp for later use
+	cp ${IMGDIR}/boot/loader.efi tmp/loader.efi
+
 
 	unset PKG_DBDIR
 	mv ${IMGDIR}/tmp/pkgdb/* ${IMGDIR}/var/db/pkg/


### PR DESCRIPTION
Boot fixed and tested.

Decided using temp space for holding efi loader was best option without going as far as porting over even more of orignal script and structure of script from FreeBSD.

Boot dir still has minimal diff from freebsd but all our additional overlays that don't apply to pi or can be added later