### PR TITLE
drop htop for now

### DIFF
--- a/manifests/trueos-snapshot-builder.json
+++ b/manifests/trueos-snapshot-builder.json
@@ -148,7 +148,6 @@
 				"os/kernel-symbols@all",
 				"ports-mgmt/poudriere-trueos",
 				"shells/zsh",
-				"sysutils/htop",
 				"sysutils/rpi-firmware",
 				"sysutils/smartmontools",
 				"sysutils/u-boot-rpi3",


### PR DESCRIPTION
we need a fresh set of packages to be able to build lsof again.